### PR TITLE
fix: appgw rewrite rules

### DIFF
--- a/infra-ai-hub/main.tf
+++ b/infra-ai-hub/main.tf
@@ -1155,12 +1155,6 @@ module "app_gateway" {
           name          = "map-ocp-apim-key-to-api-key"
           rule_sequence = 90
           conditions = {
-            path_contains_openai_or_docint = {
-              variable    = "var_uri_path"
-              pattern     = ".*(openai|documentintelligence).*"
-              ignore_case = true
-              negate      = false
-            }
             ocp_apim_subscription_key_present = {
               variable    = "http_req_Ocp-Apim-Subscription-Key"
               pattern     = ".+"


### PR DESCRIPTION
tiny pr , app gw will now pass down the header Ocp-Apim-Subscription-Key as api-key to apim irrespective of path