### PR TITLE
feat: resource health for hub resources with email and teams alert, teams webhook will be configured later.

### DIFF
--- a/infra-ai-hub/params/prod/shared.tfvars
+++ b/infra-ai-hub/params/prod/shared.tfvars
@@ -178,4 +178,29 @@ shared_config = {
     sku                           = "S"
     public_network_access_enabled = false
   }
+
+  # ---------------------------------------------------------------------------
+  # Monitoring — Resource Health + Service Health alerts → Teams webhook
+  # The Teams webhook URL is set via CI/CD secret: TF_VAR_monitoring_webhook_url.
+  # ---------------------------------------------------------------------------
+  monitoring = {
+    enabled = true
+
+    # Regions to watch for Azure Service Health events.
+    service_health_locations = ["Canada Central", "Canada East"]
+
+    # Azure services covered by the service health alert.
+    service_health_services = [
+      "Azure API Management",
+      "Azure AI model inference",
+      "Azure OpenAI",
+      "Azure Cognitive Services",
+      "Azure Key Vault",
+      "Application Gateway",
+    ]
+
+    # Email addresses to notify on hub health alerts.
+    # Teams webhook URL is set via monitoring_webhook_url in sensitive tfvars.
+    alert_emails = ["omprakash.2.mishra@gov.bc.ca"]
+  }
 }

--- a/infra-ai-hub/params/test/shared.tfvars
+++ b/infra-ai-hub/params/test/shared.tfvars
@@ -160,6 +160,31 @@ shared_config = {
     sku                           = "S"
     public_network_access_enabled = false
   }
+
+  # ---------------------------------------------------------------------------
+  # Monitoring — Resource Health + Service Health alerts → Teams webhook
+  # ---------------------------------------------------------------------------
+  monitoring = {
+    enabled = true
+
+    # Regions to watch for Azure Service Health events.
+    # Includes primary deployment region and AI cross-region location.
+    service_health_locations = ["Canada Central", "Canada East"]
+
+    # Azure services covered by the service health alert.
+    service_health_services = [
+      "Azure API Management",
+      "Azure AI model inference",
+      "Azure OpenAI",
+      "Azure Cognitive Services",
+      "Azure Key Vault",
+      "Application Gateway",
+    ]
+
+    # Email addresses to notify on hub health alerts.
+    # Teams webhook URL is set via monitoring_webhook_url in sensitive tfvars.
+    alert_emails = ["omprakash.2.mishra@gov.bc.ca"]
+  }
 }
 
 # =============================================================================

--- a/infra-ai-hub/stacks/apim/locals.tf
+++ b/infra-ai-hub/stacks/apim/locals.tf
@@ -144,4 +144,11 @@ locals {
       ] if local.apim_config.enabled
     ]) : pair.key => pair
   }
+
+  # ---------------------------------------------------------------------------
+  # Monitoring configuration — mirrors the enabled flag from shared_config
+  # ---------------------------------------------------------------------------
+  monitoring_config = {
+    enabled = lookup(lookup(var.shared_config, "monitoring", {}), "enabled", false)
+  }
 }

--- a/infra-ai-hub/stacks/apim/monitoring.tf
+++ b/infra-ai-hub/stacks/apim/monitoring.tf
@@ -1,0 +1,35 @@
+# =============================================================================
+# APIM RESOURCE HEALTH MONITORING
+# =============================================================================
+# Attaches a Resource Health alert for the APIM instance to the shared hub
+# action group (Teams webhook) provisioned in the shared stack.
+#
+# Prerequisite: monitoring must be enabled in shared_config.monitoring and
+# the shared stack must have been applied first (action group is in its state).
+# =============================================================================
+
+resource "azurerm_monitor_activity_log_alert" "apim_health" {
+  count = local.monitoring_config.enabled && local.apim_config.enabled ? 1 : 0
+
+  name                = "${var.app_name}-${var.app_env}-apim-health"
+  resource_group_name = data.terraform_remote_state.shared.outputs.resource_group_name
+  location            = "global"
+  scopes              = [module.apim[0].id]
+  description         = "Alert when APIM resource health becomes Unavailable or Degraded"
+
+  criteria {
+    category = "ResourceHealth"
+
+    resource_health {
+      current  = ["Unavailable", "Degraded", "Unknown"]
+      previous = ["Available"]
+      reason   = ["PlatformInitiated", "Unknown"]
+    }
+  }
+
+  action {
+    action_group_id = data.terraform_remote_state.shared.outputs.hub_alerts_action_group_id
+  }
+
+  tags = var.common_tags
+}

--- a/infra-ai-hub/stacks/shared/monitoring.tf
+++ b/infra-ai-hub/stacks/shared/monitoring.tf
@@ -1,0 +1,204 @@
+# =============================================================================
+# RESOURCE & SERVICE HEALTH MONITORING
+# =============================================================================
+# Scope: Hub-level resources in the shared stack.
+#   - Resource Health: per-resource alerts (Unavailable / Degraded / Unknown)
+#   - Service Health:  Azure platform incident / maintenance alerts
+#
+# Notification channels (at least one required when monitoring is enabled):
+#   - monitoring_webhook_url   : Teams Power Automate webhook
+#   - monitoring_alert_emails  : list of email addresses
+# Both can be provided simultaneously. Config goes in sensitive tfvars.
+# =============================================================================
+
+# ---------------------------------------------------------------------------
+# Validation — fail plan when monitoring is enabled with no receiver configured
+# ---------------------------------------------------------------------------
+resource "terraform_data" "monitoring_channel_validation" {
+  lifecycle {
+    precondition {
+      condition     = !local.monitoring_config.enabled || local.monitoring_config.has_any_receiver
+      error_message = "monitoring is enabled but no notification channel is configured. Set monitoring_webhook_url and/or monitoring_alert_emails in your sensitive tfvars."
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Action Group — Teams webhook and/or email receivers
+# ---------------------------------------------------------------------------
+resource "azurerm_monitor_action_group" "hub_alerts" {
+  count = local.monitoring_config.enabled ? 1 : 0
+
+  name                = "${var.app_name}-${var.app_env}-hub-alerts"
+  resource_group_name = azurerm_resource_group.main.name
+  short_name          = "hub-alerts"
+
+  dynamic "webhook_receiver" {
+    for_each = trim(var.monitoring_webhook_url, " ") != "" ? [1] : []
+    content {
+      name                    = "teams"
+      service_uri             = var.monitoring_webhook_url
+      use_common_alert_schema = true
+    }
+  }
+
+  dynamic "email_receiver" {
+    for_each = { for idx, addr in local.monitoring_config.alert_emails : tostring(idx) => addr }
+    content {
+      name                    = "email-${email_receiver.key}"
+      email_address           = email_receiver.value
+      use_common_alert_schema = true
+    }
+  }
+
+  tags = var.common_tags
+
+  depends_on = [terraform_data.monitoring_channel_validation]
+}
+
+# ---------------------------------------------------------------------------
+# Resource Health — AI Foundry Hub
+# ---------------------------------------------------------------------------
+resource "azurerm_monitor_activity_log_alert" "ai_foundry_health" {
+  count = local.monitoring_config.enabled ? 1 : 0
+
+  name                = "${var.app_name}-${var.app_env}-ai-foundry-health"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = "global"
+  scopes              = [module.ai_foundry_hub.id]
+  description         = "Alert when AI Foundry Hub resource health becomes Unavailable or Degraded"
+
+  criteria {
+    category = "ResourceHealth"
+
+    resource_health {
+      current  = ["Unavailable", "Degraded", "Unknown"]
+      previous = ["Available"]
+      reason   = ["PlatformInitiated", "Unknown"]
+    }
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.hub_alerts[0].id
+  }
+
+  tags = var.common_tags
+}
+
+# ---------------------------------------------------------------------------
+# Resource Health — Language Service (conditional on service being enabled)
+# ---------------------------------------------------------------------------
+resource "azurerm_monitor_activity_log_alert" "language_service_health" {
+  count = local.monitoring_config.enabled && var.shared_config.language_service.enabled ? 1 : 0
+
+  name                = "${var.app_name}-${var.app_env}-language-health"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = "global"
+  scopes              = [azurerm_cognitive_account.language_service[0].id]
+  description         = "Alert when Language Service resource health becomes Unavailable or Degraded"
+
+  criteria {
+    category = "ResourceHealth"
+
+    resource_health {
+      current  = ["Unavailable", "Degraded", "Unknown"]
+      previous = ["Available"]
+      reason   = ["PlatformInitiated", "Unknown"]
+    }
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.hub_alerts[0].id
+  }
+
+  tags = var.common_tags
+}
+
+# ---------------------------------------------------------------------------
+# Resource Health — Hub Key Vault
+# ---------------------------------------------------------------------------
+resource "azurerm_monitor_activity_log_alert" "hub_kv_health" {
+  count = local.monitoring_config.enabled ? 1 : 0
+
+  name                = "${var.app_name}-${var.app_env}-hub-kv-health"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = "global"
+  scopes              = [module.hub_key_vault.resource_id]
+  description         = "Alert when Hub Key Vault resource health becomes Unavailable or Degraded"
+
+  criteria {
+    category = "ResourceHealth"
+
+    resource_health {
+      current  = ["Unavailable", "Degraded", "Unknown"]
+      previous = ["Available"]
+      reason   = ["PlatformInitiated", "Unknown"]
+    }
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.hub_alerts[0].id
+  }
+
+  tags = var.common_tags
+}
+
+# ---------------------------------------------------------------------------
+# Resource Health — Application Gateway (conditional on App Gateway enabled)
+# ---------------------------------------------------------------------------
+resource "azurerm_monitor_activity_log_alert" "app_gateway_health" {
+  count = local.monitoring_config.enabled && local.appgw_config.enabled ? 1 : 0
+
+  name                = "${var.app_name}-${var.app_env}-appgw-health"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = "global"
+  scopes              = [module.app_gateway[0].id]
+  description         = "Alert when App Gateway resource health becomes Unavailable or Degraded"
+
+  criteria {
+    category = "ResourceHealth"
+
+    resource_health {
+      current  = ["Unavailable", "Degraded", "Unknown"]
+      previous = ["Available"]
+      reason   = ["PlatformInitiated", "Unknown"]
+    }
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.hub_alerts[0].id
+  }
+
+  tags = var.common_tags
+}
+
+# ---------------------------------------------------------------------------
+# Service Health — Azure platform incidents & maintenance for hub services
+#
+# Covers Incident, Maintenance, Informational, and ActionRequired events for
+# the Azure services that power this hub. Scoped to the subscription so that
+# any regional impact to the configured service_health_services is captured.
+# ---------------------------------------------------------------------------
+resource "azurerm_monitor_activity_log_alert" "service_health" {
+  count = local.monitoring_config.enabled ? 1 : 0
+
+  name                = "${var.app_name}-${var.app_env}-service-health"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = "global"
+  scopes              = [data.azurerm_subscription.current.id]
+  description         = "Azure service health alerts for hub-level services (incidents, maintenance, action required)"
+
+  criteria {
+    category = "ServiceHealth"
+
+    service_health {
+      locations = local.monitoring_config.service_health_locations
+    }
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.hub_alerts[0].id
+  }
+
+  tags = var.common_tags
+}

--- a/infra-ai-hub/stacks/shared/outputs.tf
+++ b/infra-ai-hub/stacks/shared/outputs.tf
@@ -104,3 +104,8 @@ output "appgw_url" {
   description = "App Gateway frontend URL (https://<frontend_hostname>). Null when App Gateway is not deployed."
   value       = length(module.app_gateway) > 0 ? "https://${lookup(local.appgw_config, "frontend_hostname", "")}" : null
 }
+
+output "hub_alerts_action_group_id" {
+  description = "Resource ID of the hub monitoring action group. Referenced by the APIM stack to attach APIM resource health alerts."
+  value       = length(azurerm_monitor_action_group.hub_alerts) > 0 ? azurerm_monitor_action_group.hub_alerts[0].id : null
+}

--- a/infra-ai-hub/stacks/shared/variables.tf
+++ b/infra-ai-hub/stacks/shared/variables.tf
@@ -110,3 +110,10 @@ variable "backend_container_name" {
   type        = string
   default     = "tfstate"
 }
+
+variable "monitoring_webhook_url" {
+  description = "Teams Power Automate webhook URL for hub alert notifications. Optional — provide this and/or alert_emails in shared_config.monitoring. Store in sensitive tfvars, never in source-controlled params."
+  type        = string
+  sensitive   = true
+  default     = ""
+}


### PR DESCRIPTION


<!-- ai-hub-infra-changes -->
## AI Hub Infra Changes

**Summary:** 1 to add, 32 to change, 1 to destroy (across 2 stack(s))

<details><summary>Show plan details</summary>

```hcl
Terraform will perform the following actions:

  # module.hub_key_vault.azurerm_role_assignment.this["deployer_secrets_officer"] must be replaced
-/+ resource "azurerm_role_assignment" "this" {
      + condition_version                      = (known after apply)
      ~ id                                     = "/subscriptions/****/resourceGroups/ai-services-hub-test/providers/Microsoft.KeyVault/vaults/ai-services-hub-test-hkv/providers/Microsoft.Authorization/roleAssignments/****" -> (known after apply)
      ~ name                                   = "****" -> (known after apply)
      ~ principal_id                           = "****" -> "****" # forces replacement
      ~ principal_type                         = "User" -> (known after apply)
      ~ role_definition_id                     = "/subscriptions/****/providers/Microsoft.Authorization/roleDefinitions/****" -> (known after apply)
        # (6 unchanged attributes hidden)
    }

Plan: 1 to add, 0 to change, 1 to destroy.

Warning: Argument is deprecated

  with module.hub_key_vault.azurerm_key_vault.this,
  on .terraform/modules/hub_key_vault/main.tf line 7, in resource "azurerm_key_vault" "this":
   7:   enable_rbac_authorization       = !var.legacy_access_policies_enabled

This property has been renamed to `rbac_authorization_enabled` and will be
removed in v5.0 of the provider

─────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't
guarantee to take exactly these actions if you run "terraform apply" now.
Releasing state lock. This may take a few moments...
2026-02-21T05:09:39Z [SUCCESS] terraform plan (shared) (attempt 1/5) completed successfully
2026-02-21T05:09:42Z [INFO] Running 3 tenants in parallel
2026-02-21T05:09:42Z [INFO] Starting terraform init (tenant:nr-dap-fish-wildlife)
2026-02-21T05:09:43.011Z [INFO]  Terraform version: 1.12.2
2026-02-21T05:09:43.011Z [INFO]  Go runtime version: go1.24.2
2026-02-21T05:09:43.011Z [INFO]  CLI args: []string{"terraform", "init", "-input=false", "-upgrade", "-reconfigure", "-backend-config=resource_group_name=da4cf6-test-networking", "-backend-config=storage_account_name=tftestaihubtracking", "-backend-config=container_name=tfstate", "-backend-config=key=ai-services-hub/test/tenant-nr-dap-fish-wildlife.tfstate", "-backend-config=subscription_id=****", "-backend-config=tenant_id=****", "-backend-config=client_id=****", "-backend-config=use_oidc=true"}
2026-02-21T05:09:43.011Z [INFO]  TF_CLI_ARGS value: "-no-color"
2026-02-21T05:09:43.011Z [INFO]  CLI command args: []string{"init", "-no-color", "-input=false", "-upgrade", "-reconfigure", "-backend-config=resource_group_name=da4cf6-test-networking", "-backend-config=storage_account_name=tftestaihubtracking", "-backend-config=container_name=tfstate", "-backend-config=key=ai-services-hub/test/tenant-nr-dap-fish-wildlife.tfstate", "-backend-config=subscription_id=****", "-backend-config=tenant_id=****", "-backend-config=client_id=****", "-backend-config=use_oidc=true"}
Initializing the backend...

Successfully configured the backend "azurerm"! Terraform will automatically
use this backend unless the backend configuration changes.
Upgrading modules...
- tenant in ../../modules/tenant
Downloading registry.terraform.io/Azure/avm-res-search-searchservice/azurerm 0.2.0 for tenant.ai_search...
- tenant.ai_search in /home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-nr-dap-fish-wildlife/modules/tenant.ai_search
Downloading registry.terraform.io/Azure/avm-res-cognitiveservices-account/azurerm 0.6.0 for tenant.document_intelligence...
- tenant.document_intelligence in /home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-nr-dap-fish-wildlife/modules/tenant.document_intelligence
Downloading registry.terraform.io/Azure/avm-res-keyvault-vault/azurerm 0.10.2 for tenant.key_vault...
- tenant.key_vault in /home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-nr-dap-fish-wildlife/modules/tenant.key_vault
- tenant.key_vault.keys in /home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-nr-dap-fish-wildlife/modules/tenant.key_vault/modules/key
- tenant.key_vault.secrets in /home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-nr-dap-fish-wildlife/modules/tenant.key_vault/modules/secret
Downloading registry.terraform.io/Azure/avm-res-cognitiveservices-account/azurerm 0.6.0 for tenant.speech_services...
- tenant.speech_services in /home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-nr-dap-fish-wildlife/modules/tenant.speech_services
Initializing provider plugins...
- terraform.io/builtin/terraform is built in to Terraform
- Finding hashicorp/azurerm versions matching ">= 3.117.0, ~> 4.0, >= 4.38.0, < 5.0.0"...
- Finding azure/azapi versions matching "~> 2.0, ~> 2.4, >= 2.5.0"...
- Finding hashicorp/null versions matching ">= 3.2.0"...
- Finding azure/modtm versions matching "~> 0.3, >= 0.3.2, < 1.0.0"...
- Finding hashicorp/random versions matching ">= 3.5.0, ~> 3.5, >= 3.7.0"...
- Finding hashicorp/time versions matching "~> 0.9"...
- Installing hashicorp/azurerm v4.61.0...
- Installed hashicorp/azurerm v4.61.0 (signed by HashiCorp)
- Installing azure/azapi v2.8.0...
- Installed azure/azapi v2.8.0 (signed by a HashiCorp partner, key ID 6F0B91BDE98478CF)
- Installing hashicorp/null v3.2.4...
- Installed hashicorp/null v3.2.4 (signed by HashiCorp)
- Installing azure/modtm v0.3.5...
- Installed azure/modtm v0.3.5 (signed by a HashiCorp partner, key ID 6F0B91BDE98478CF)
- Installing hashicorp/random v3.8.1...
- Installed hashicorp/random v3.8.1 (signed by HashiCorp)
- Installing hashicorp/time v0.13.1...
- Installed hashicorp/time v0.13.1 (signed by HashiCorp)
Partner and community providers are signed by their developers.
If you'd like to know more about provider signing, you can read about it here:
https://developer.hashicorp.com/terraform/cli/plugins/signing
Terraform has created a lock file .terraform.lock.hcl to record the provider
selections it made above. Include this file in your version control repository
so that Terraform can guarantee to make the same selections by default when
you run "terraform init" in the future.

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
2026-02-21T05:09:57Z [SUCCESS] terraform init (tenant:nr-dap-fish-wildlife) completed successfully
2026-02-21T05:09:57Z [INFO] Starting terraform plan (tenant:nr-dap-fish-wildlife) (attempt 1/5)
2026-02-21T05:09:57.140Z [INFO]  Terraform version: 1.12.2
2026-02-21T05:09:57.141Z [INFO]  Go runtime version: go1.24.2
2026-02-21T05:09:57.141Z [INFO]  CLI args: []string{"terraform", "plan", "-input=false", "-var-file=/home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/params/test/shared.tfvars", "-var-file=/home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.tenant-test-nr-dap-fish-wildlife.auto.tfvars", "-var=backend_resource_group=da4cf6-test-networking", "-var=backend_storage_account=tftestaihubtracking", "-var=backend_container_name=tfstate", "-var=app_env=test"}
2026-02-21T05:09:57.141Z [INFO]  TF_CLI_ARGS value: "-no-color"
2026-02-21T05:09:57.141Z [INFO]  CLI command args: []string{"plan", "-no-color", "-input=false", "-var-file=/home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/params/test/shared.tfvars", "-var-file=/home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.tenant-test-nr-dap-fish-wildlife.auto.tfvars", "-var=backend_resource_group=da4cf6-test-networking", "-var=backend_storage_account=tftestaihubtracking", "-var=backend_container_name=tfstate", "-var=app_env=test"}
2026-02-21T05:09:58.782Z [INFO]  backend/local: starting Plan operation
Acquiring state lock. This may take a few moments...
2026-02-21T05:10:01.892Z [INFO]  provider: configuring client automatic mTLS
2026-02-21T05:10:01.905Z [INFO]  provider.terraform-provider-azapi_v2.8.0: configuring server automatic mTLS: timestamp=2026-02-21T05:10:01.905Z
2026-02-21T05:10:01.939Z [INFO]  provider: plugin process exited: plugin=/home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-nr-dap-fish-wildlife/providers/registry.terraform.io/azure/azapi/2.8.0/linux_amd64/terraform-provider-azapi_v2.8.0 id=3701
2026-02-21T05:10:01.939Z [INFO]  provider: configuring client automatic mTLS
2026-02-21T05:10:01.950Z [INFO]  provider.terraform-provider-modtm_v0.3.5: configuring server automatic mTLS: timestamp=2026-02-21T05:10:01.950Z
2026-02-21T05:10:01.987Z [INFO]  provider: plugin process exited: plugin=/home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-nr-dap-fish-wildlife/providers/registry.terraform.io/azure/modtm/0.3.5/linux_amd64/terraform-provider-modtm_v0.3.5 id=3727
2026-02-21T05:10:01.987Z [INFO]  provider: configuring client automatic mTLS
2026-02-21T05:10:02.095Z [INFO]  provider.terraform-provider-azurerm_v4.61.0_x5: configuring server automatic mTLS: timestamp=2026-02-21T05:10:02.095Z
2026-02-21T05:10:02.476Z [INFO]  provider: plugin process exited: plugin=/home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-nr-dap-fish-wildlife/providers/registry.terraform.io/hashicorp/azurerm/4.61.0/linux_amd64/terraform-provider-azurerm_v4.61.0_x5 id=3748
2026-02-21T05:10:02.476Z [INFO]  provider: configuring client automatic mTLS
2026-02-21T05:10:02.488Z [INFO]  provider.terraform-provider-null_v3.2.4_x5: configuring server automatic mTLS: timestamp=2026-02-21T05:10:02.488Z
2026-02-21T05:10:02.524Z [INFO]  provider: plugin process exited: plugin=/home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-nr-dap-fish-wildlife/providers/registry.terraform.io/hashicorp/null/3.2.4/linux_amd64/terraform-provider-null_v3.2.4_x5 id=3783
2026-02-21T05:10:02.524Z [INFO]  provider: configuring client automatic mTLS
2026-02-21T05:10:02.534Z [INFO]  provider.terraform-provider-random_v3.8.1_x5: configuring server automatic mTLS: timestamp=2026-02-21T05:10:02.534Z
2026-02-21T05:10:02.570Z [INFO]  provider: plugin process exited: plugin=/home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-nr-dap-fish-wildlife/providers/registry.terraform.io/hashicorp/random/3.8.1/linux_amd64/terraform-provider-random_v3.8.1_x5 id=3805
2026-02-21T05:10:02.570Z [INFO]  provider: configuring client automatic mTLS
2026-02-21T05:10:02.581Z [INFO]  provider.terraform-provider-time_v0.13.1_x5: configuring server automatic mTLS: timestamp=2026-02-21T05:10:02.581Z
2026-02-21T05:10:02.621Z [INFO]  provider: plugin process exited: plugin=/home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-nr-dap-fish-wildlife/providers/registry.terraform.io/hashicorp/time/0.13.1/linux_amd64/terraform-provider-time_v0.13.1_x5 id=3830
2026-02-21T05:10:02.632Z [ERROR] AttachSchemaTransformer: No provider config schema available for provider["terraform.io/builtin/terraform"]
2026-02-21T05:10:02.765Z [INFO]  provider: configuring client automatic mTLS
2026-02-21T05:10:02.780Z [INFO]  provider.terraform-provider-null_v3.2.4_x5: configuring server automatic mTLS: timestamp=2026-02-21T05:10:02.780Z
2026-02-21T05:10:02.806Z [INFO]  provider: configuring client automatic mTLS
2026-02-21T05:10:02.819Z [INFO]  provider.terraform-provider-time_v0.13.1_x5: configuring server automatic mTLS: timestamp=2026-02-21T05:10:02.819Z
2026-02-21T05:10:02.853Z [INFO]  provider: configuring client au
(truncated, see workflow logs for complete plan)
```

</details>

---
_Updated by CI — plan against `test` environment (run [#191](https://github.com/bcgov/ai-hub-tracking/actions/runs/22250844618))._
<!-- /ai-hub-infra-changes -->