### PR TITLE
feat: APIM circuit breaker

### DIFF
--- a/docs/_pages/decisions.html
+++ b/docs/_pages/decisions.html
@@ -227,6 +227,12 @@ details.adr.pending[open] summary {
         <td><span class="badge badge-blue">Policy</span></td>
         <td><span class="badge" style="background:#f59e0b;color:white;">Pending Platform/MS</span></td>
     </tr>
+    <tr>
+        <td><a href="#adr-016">ADR-016</a></td>
+        <td>Backend Circuit Breaker Pattern</td>
+        <td><span class="badge" style="background:#22c55e;color:white;">Resilience</span></td>
+        <td><span class="badge badge-blue">Accepted</span></td>
+    </tr>
 </table>
 
 <!-- ADR-001 -->
@@ -2952,6 +2958,113 @@ module "storage" {
         <li><a href="#adr-013">ADR-013: Scaled Stack Architecture</a> &mdash; phased deployment with isolated state</li>
         <li><a href="https://learn.microsoft.com/en-us/azure/ai-services/openai/quotas-limits">Azure OpenAI Quotas and Limits</a></li>
         <li><a href="https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/azure-subscription-service-limits">Azure Subscription Service Limits</a></li>
+    </ul>
+
+</div>
+</details>
+
+<!-- ADR-016 -->
+<details class="adr" id="adr-016">
+<summary>
+    <span class="adr-title">ADR-016: Backend Circuit Breaker Pattern</span>
+    <span class="badge" style="background:#22c55e;color:white;">Resilience</span>
+    <span class="badge badge-blue">Accepted</span>
+</summary>
+<div class="adr-content" style="padding: 1.5rem;">
+
+    <table class="config-table">
+        <tr><td><strong>Status</strong></td><td>Accepted</td></tr>
+        <tr><td><strong>Date</strong></td><td>2026-02</td></tr>
+        <tr><td><strong>Deciders</strong></td><td>Platform Team</td></tr>
+        <tr><td><strong>Category</strong></td><td>Resilience / API Gateway</td></tr>
+    </table>
+
+    <h3 style="color: var(--bc-blue); margin-top: 1.5rem;">Context</h3>
+    <p>The APIM gateway proxies requests to multiple backend services: Azure OpenAI, Document Intelligence, AI Search, Speech Services, and Storage. When a backend experiences failures (overload, outages, throttling), continued request forwarding wastes resources and degrades the client experience with slow timeouts instead of fast failures.</p>
+    <p>Azure OpenAI specifically returns <code>429 Too Many Requests</code> with large <code>Retry-After</code> values (up to 86,400 seconds / 1 day) when quota is exhausted. Without circuit breaking, APIM would continue sending requests to a backend that cannot serve them.</p>
+
+    <h3 style="color: var(--bc-blue); margin-top: 1.5rem;">Decision</h3>
+    <p>Implement the <strong>circuit breaker pattern</strong> on all APIM backend entities using the native <code>circuit_breaker_rule</code> in <code>azurerm_api_management_backend</code>.</p>
+
+    <h4>Configuration per backend</h4>
+    <table class="config-table" style="width: 100%; margin-top: 0.5rem;">
+        <thead>
+            <tr><th>Parameter</th><th>Value (AI services)</th><th>Value (Storage)</th></tr>
+        </thead>
+        <tbody>
+            <tr><td>Failure count threshold</td><td>3</td><td>5</td></tr>
+            <tr><td>Failure window</td><td>1 minute (<code>PT1M</code>)</td><td>1 minute (<code>PT1M</code>)</td></tr>
+            <tr><td>Trip duration</td><td>1 minute (<code>PT1M</code>)</td><td>1 minute (<code>PT1M</code>)</td></tr>
+            <tr><td>Accept Retry-After</td><td>Yes</td><td>Yes</td></tr>
+            <tr><td>Trigger status codes</td><td><code>429</code>, <code>500&ndash;599</code></td><td><code>429</code>, <code>500&ndash;599</code></td></tr>
+        </tbody>
+    </table>
+
+    <h4>Backends covered</h4>
+    <ul>
+        <li><code>ai_foundry</code> &mdash; AI Foundry Hub endpoint</li>
+        <li><code>openai</code> &mdash; Azure OpenAI endpoint</li>
+        <li><code>docint</code> &mdash; Document Intelligence</li>
+        <li><code>ai_search</code> &mdash; Azure AI Search</li>
+        <li><code>speech_services_stt</code> &mdash; Speech-to-Text</li>
+        <li><code>speech_services_tts</code> &mdash; Text-to-Speech</li>
+        <li><code>storage</code> &mdash; Blob Storage (higher threshold: 5 failures)</li>
+    </ul>
+
+    <h4>What happens when the circuit trips</h4>
+    <ol>
+        <li>Backend accumulates failures matching the configured status codes within the failure window.</li>
+        <li>When the failure count exceeds the threshold, the circuit <strong>opens</strong> (trips).</li>
+        <li>APIM immediately returns <strong>HTTP 503 Service Unavailable</strong> to all subsequent requests targeting that backend &mdash; requests are <em>not</em> forwarded.</li>
+        <li>The global policy <code>&lt;on-error&gt;</code> handler intercepts the 503 and returns a structured JSON error with a <code>Retry-After</code> header (default: 60 seconds).</li>
+        <li>After the trip duration (or the backend&rsquo;s <code>Retry-After</code> value if <code>accept_retry_after_enabled = true</code>), the circuit <strong>resets</strong> and traffic resumes.</li>
+    </ol>
+
+    <div class="alert alert-warning">
+        <strong>Azure OpenAI caution:</strong> When Azure OpenAI returns <code>429</code>, the <code>Retry-After</code> header can be very large (e.g., 86,400 seconds = 1 day). With <code>accept_retry_after_enabled = true</code>, the circuit stays open for that duration. This is intentional &mdash; the backend cannot serve requests during that period anyway.
+    </div>
+
+    <h4>Client-facing error response (503)</h4>
+    <pre style="background: var(--bg-light); padding: 1rem; border-radius: 8px; font-size: 0.85rem; overflow-x: auto;">{
+  "error": {
+    "code": "503",
+    "message": "Service temporarily unavailable — backend circuit breaker is open. The service is recovering from excessive failures. Retry after the indicated period.",
+    "retryAfter": "60",
+    "requestId": "abc-123-def-456"
+  }
+}</pre>
+
+    <h3 style="color: var(--bc-blue); margin-top: 1.5rem;">Rationale</h3>
+    <ul>
+        <li><strong>Fast failure:</strong> Clients get an immediate 503 instead of waiting for backend timeouts (up to 300 seconds).</li>
+        <li><strong>Backend protection:</strong> Prevents overwhelming a struggling backend with additional requests.</li>
+        <li><strong>Native support:</strong> Uses <code>azurerm_api_management_backend.circuit_breaker_rule</code> &mdash; no custom policy logic required.</li>
+        <li><strong>Retry-After propagation:</strong> Passes backend throttle signals directly to clients for proper backoff.</li>
+        <li><strong>Event Grid integration:</strong> APIM emits Event Grid events on circuit trip/reset for monitoring and alerting.</li>
+    </ul>
+
+    <h3 style="color: var(--bc-blue); margin-top: 1.5rem;">Consequences</h3>
+    <h4>Positive</h4>
+    <ul>
+        <li>Reduced latency during backend outages (instant 503 vs. timeout).</li>
+        <li>Backend services get breathing room to recover.</li>
+        <li>Consistent error format with <code>Retry-After</code> enables client-side retry logic.</li>
+        <li>Zero policy-level code &mdash; purely infrastructure configuration.</li>
+    </ul>
+
+    <h4>Negative</h4>
+    <ul>
+        <li><strong>Approximate tripping:</strong> APIM gateway instances do not synchronize circuit breaker state. Each instance tracks failures independently, so tripping is approximate in multi-instance deployments.</li>
+        <li><strong>Single rule per backend:</strong> Only one circuit breaker rule per backend is currently supported by the Azure API.</li>
+        <li><strong>503 during recovery:</strong> Legitimate requests during the trip window will be rejected even if the backend has recovered before the trip duration expires.</li>
+    </ul>
+
+    <h3 style="color: var(--bc-blue); margin-top: 1.5rem;">References</h3>
+    <ul>
+        <li><a href="https://learn.microsoft.com/en-us/azure/api-management/backends?tabs=bicep#circuit-breaker">Azure APIM Backends &mdash; Circuit Breaker</a></li>
+        <li><a href="https://learn.microsoft.com/en-us/azure/architecture/patterns/circuit-breaker">Circuit Breaker Pattern (Azure Architecture)</a></li>
+        <li><a href="https://learn.microsoft.com/en-us/azure/event-grid/event-schema-api-management">APIM Event Grid Events</a> &mdash; circuit breaker trip/reset events</li>
+        <li><a href="https://github.com/bcgov/ai-hub-tracking/issues/98">Issue #98: AI Gateway Gap Analysis</a></li>
     </ul>
 
 </div>

--- a/docs/decisions.html
+++ b/docs/decisions.html
@@ -1305,6 +1305,12 @@ details.adr.pending[open] summary {
         <td><span class="badge badge-blue">Policy</span></td>
         <td><span class="badge" style="background:#f59e0b;color:white;">Pending Platform/MS</span></td>
     </tr>
+    <tr>
+        <td><a href="#adr-016">ADR-016</a></td>
+        <td>Backend Circuit Breaker Pattern</td>
+        <td><span class="badge" style="background:#22c55e;color:white;">Resilience</span></td>
+        <td><span class="badge badge-blue">Accepted</span></td>
+    </tr>
 </table>
 
 <details class="adr" id="adr-001" open>
@@ -4015,6 +4021,112 @@ module "storage" {
         <li><a href="#adr-013">ADR-013: Scaled Stack Architecture</a> &mdash; phased deployment with isolated state</li>
         <li><a href="https://learn.microsoft.com/en-us/azure/ai-services/openai/quotas-limits">Azure OpenAI Quotas and Limits</a></li>
         <li><a href="https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/azure-subscription-service-limits">Azure Subscription Service Limits</a></li>
+    </ul>
+
+</div>
+</details>
+
+<details class="adr" id="adr-016">
+<summary>
+    <span class="adr-title">ADR-016: Backend Circuit Breaker Pattern</span>
+    <span class="badge" style="background:#22c55e;color:white;">Resilience</span>
+    <span class="badge badge-blue">Accepted</span>
+</summary>
+<div class="adr-content" style="padding: 1.5rem;">
+
+    <table class="config-table">
+        <tr><td><strong>Status</strong></td><td>Accepted</td></tr>
+        <tr><td><strong>Date</strong></td><td>2026-02</td></tr>
+        <tr><td><strong>Deciders</strong></td><td>Platform Team</td></tr>
+        <tr><td><strong>Category</strong></td><td>Resilience / API Gateway</td></tr>
+    </table>
+
+    <h3 id="context-15" style="color: var(--bc-blue); margin-top: 1.5rem;">Context</h3>
+    <p>The APIM gateway proxies requests to multiple backend services: Azure OpenAI, Document Intelligence, AI Search, Speech Services, and Storage. When a backend experiences failures (overload, outages, throttling), continued request forwarding wastes resources and degrades the client experience with slow timeouts instead of fast failures.</p>
+    <p>Azure OpenAI specifically returns <code>429 Too Many Requests</code> with large <code>Retry-After</code> values (up to 86,400 seconds / 1 day) when quota is exhausted. Without circuit breaking, APIM would continue sending requests to a backend that cannot serve them.</p>
+
+    <h3 id="decision-12" style="color: var(--bc-blue); margin-top: 1.5rem;">Decision</h3>
+    <p>Implement the <strong>circuit breaker pattern</strong> on all APIM backend entities using the native <code>circuit_breaker_rule</code> in <code>azurerm_api_management_backend</code>.</p>
+
+    <h4>Configuration per backend</h4>
+    <table class="config-table" style="width: 100%; margin-top: 0.5rem;">
+        <thead>
+            <tr><th>Parameter</th><th>Value (AI services)</th><th>Value (Storage)</th></tr>
+        </thead>
+        <tbody>
+            <tr><td>Failure count threshold</td><td>3</td><td>5</td></tr>
+            <tr><td>Failure window</td><td>1 minute (<code>PT1M</code>)</td><td>1 minute (<code>PT1M</code>)</td></tr>
+            <tr><td>Trip duration</td><td>1 minute (<code>PT1M</code>)</td><td>1 minute (<code>PT1M</code>)</td></tr>
+            <tr><td>Accept Retry-After</td><td>Yes</td><td>Yes</td></tr>
+            <tr><td>Trigger status codes</td><td><code>429</code>, <code>500&ndash;599</code></td><td><code>429</code>, <code>500&ndash;599</code></td></tr>
+        </tbody>
+    </table>
+
+    <h4>Backends covered</h4>
+    <ul>
+        <li><code>ai_foundry</code> &mdash; AI Foundry Hub endpoint</li>
+        <li><code>openai</code> &mdash; Azure OpenAI endpoint</li>
+        <li><code>docint</code> &mdash; Document Intelligence</li>
+        <li><code>ai_search</code> &mdash; Azure AI Search</li>
+        <li><code>speech_services_stt</code> &mdash; Speech-to-Text</li>
+        <li><code>speech_services_tts</code> &mdash; Text-to-Speech</li>
+        <li><code>storage</code> &mdash; Blob Storage (higher threshold: 5 failures)</li>
+    </ul>
+
+    <h4>What happens when the circuit trips</h4>
+    <ol>
+        <li>Backend accumulates failures matching the configured status codes within the failure window.</li>
+        <li>When the failure count exceeds the threshold, the circuit <strong>opens</strong> (trips).</li>
+        <li>APIM immediately returns <strong>HTTP 503 Service Unavailable</strong> to all subsequent requests targeting that backend &mdash; requests are <em>not</em> forwarded.</li>
+        <li>The global policy <code>&lt;on-error&gt;</code> handler intercepts the 503 and returns a structured JSON error with a <code>Retry-After</code> header (default: 60 seconds).</li>
+        <li>After the trip duration (or the backend&rsquo;s <code>Retry-After</code> value if <code>accept_retry_after_enabled = true</code>), the circuit <strong>resets</strong> and traffic resumes.</li>
+    </ol>
+
+    <div class="alert alert-warning">
+        <strong>Azure OpenAI caution:</strong> When Azure OpenAI returns <code>429</code>, the <code>Retry-After</code> header can be very large (e.g., 86,400 seconds = 1 day). With <code>accept_retry_after_enabled = true</code>, the circuit stays open for that duration. This is intentional &mdash; the backend cannot serve requests during that period anyway.
+    </div>
+
+    <h4>Client-facing error response (503)</h4>
+    <pre style="background: var(--bg-light); padding: 1rem; border-radius: 8px; font-size: 0.85rem; overflow-x: auto;">{
+  "error": {
+    "code": "503",
+    "message": "Service temporarily unavailable — backend circuit breaker is open. The service is recovering from excessive failures. Retry after the indicated period.",
+    "retryAfter": "60",
+    "requestId": "abc-123-def-456"
+  }
+}</pre>
+
+    <h3 id="rationale-8" style="color: var(--bc-blue); margin-top: 1.5rem;">Rationale</h3>
+    <ul>
+        <li><strong>Fast failure:</strong> Clients get an immediate 503 instead of waiting for backend timeouts (up to 300 seconds).</li>
+        <li><strong>Backend protection:</strong> Prevents overwhelming a struggling backend with additional requests.</li>
+        <li><strong>Native support:</strong> Uses <code>azurerm_api_management_backend.circuit_breaker_rule</code> &mdash; no custom policy logic required.</li>
+        <li><strong>Retry-After propagation:</strong> Passes backend throttle signals directly to clients for proper backoff.</li>
+        <li><strong>Event Grid integration:</strong> APIM emits Event Grid events on circuit trip/reset for monitoring and alerting.</li>
+    </ul>
+
+    <h3 id="consequences-15" style="color: var(--bc-blue); margin-top: 1.5rem;">Consequences</h3>
+    <h4>Positive</h4>
+    <ul>
+        <li>Reduced latency during backend outages (instant 503 vs. timeout).</li>
+        <li>Backend services get breathing room to recover.</li>
+        <li>Consistent error format with <code>Retry-After</code> enables client-side retry logic.</li>
+        <li>Zero policy-level code &mdash; purely infrastructure configuration.</li>
+    </ul>
+
+    <h4>Negative</h4>
+    <ul>
+        <li><strong>Approximate tripping:</strong> APIM gateway instances do not synchronize circuit breaker state. Each instance tracks failures independently, so tripping is approximate in multi-instance deployments.</li>
+        <li><strong>Single rule per backend:</strong> Only one circuit breaker rule per backend is currently supported by the Azure API.</li>
+        <li><strong>503 during recovery:</strong> Legitimate requests during the trip window will be rejected even if the backend has recovered before the trip duration expires.</li>
+    </ul>
+
+    <h3 id="references-13" style="color: var(--bc-blue); margin-top: 1.5rem;">References</h3>
+    <ul>
+        <li><a href="https://learn.microsoft.com/en-us/azure/api-management/backends?tabs=bicep#circuit-breaker">Azure APIM Backends &mdash; Circuit Breaker</a></li>
+        <li><a href="https://learn.microsoft.com/en-us/azure/architecture/patterns/circuit-breaker">Circuit Breaker Pattern (Azure Architecture)</a></li>
+        <li><a href="https://learn.microsoft.com/en-us/azure/event-grid/event-schema-api-management">APIM Event Grid Events</a> &mdash; circuit breaker trip/reset events</li>
+        <li><a href="https://github.com/bcgov/ai-hub-tracking/issues/98">Issue #98: AI Gateway Gap Analysis</a></li>
     </ul>
 
 </div>

--- a/docs/playbooks.html
+++ b/docs/playbooks.html
@@ -870,7 +870,6 @@
             color: var(--text-secondary);
             line-height: 1.55;
             display: -webkit-box;
-            line-clamp: 2;
             -webkit-line-clamp: 2;
             -webkit-box-orient: vertical;
             overflow: hidden;

--- a/infra-ai-hub/params/apim/api_policy.xml.tftpl
+++ b/infra-ai-hub/params/apim/api_policy.xml.tftpl
@@ -50,6 +50,20 @@
             </when>
         </choose>
 %{ endif ~}
+%{ if rate_limiting_enabled ~}
+        <!-- Non-OpenAI request rate limiting (per subscription) -->
+        <!-- Protects APIM compute and backends from request floods -->
+        <!-- DocInt/Speech/Search/Storage use request-count limits (not token limits) -->
+        <choose>
+            <when condition="@(!context.Request.Url.Path.ToLower().Contains(&quot;openai&quot;) && !context.Request.Url.Path.ToLower().EndsWith(&quot;internal/apim-keys&quot;) && !context.Request.Url.Path.ToLower().EndsWith(&quot;internal/tenant-info&quot;))">
+                <rate-limit-by-key
+                    calls="${non_openai_requests_per_minute}"
+                    renewal-period="60"
+                    counter-key="@(context.Subscription.Id + &quot;-non-openai&quot;)"
+                    increment-condition="@(context.Response.StatusCode >= 200)" />
+            </when>
+        </choose>
+%{ endif ~}
 
         <!-- Path-based routing to appropriate backend service -->
         <choose>
@@ -321,7 +335,8 @@
 %{ endif ~}
 %{ if storage_enabled ~}
             <!-- Storage requests: /storage/* -->
-            <when condition="@(context.Request.Url.Path.ToLower().Contains(&quot;storage&quot;))">
+            <!-- Path must start with /storage/ (after tenant prefix) to avoid false matches -->
+            <when condition="@(context.Request.Url.Path.ToLower().Contains(&quot;/storage/&quot;) || context.Request.Url.Path.ToLower().EndsWith(&quot;/storage&quot;))">
                 <set-backend-service backend-id="${tenant_name}-storage" />
                 <authentication-managed-identity resource="https://storage.azure.com" output-token-variable-name="msi-access-token" ignore-error="false" />
                 <set-header name="Authorization" exists-action="override">

--- a/infra-ai-hub/params/apim/global_policy.xml
+++ b/infra-ai-hub/params/apim/global_policy.xml
@@ -91,8 +91,40 @@
                     }</set-body>
                 </return-response>
             </when>
+            <!-- ================================================================== -->
+            <!-- CIRCUIT BREAKER HANDLING                                           -->
+            <!-- When a backend circuit breaker trips, APIM returns 503.            -->
+            <!-- Provide a clear error with Retry-After so clients can back off.    -->
+            <!-- See ADR-016 in decisions.html for circuit breaker design.          -->
+            <!-- ================================================================== -->
+            <when condition="@(context.Response.StatusCode == 503)">
+                <return-response>
+                    <set-status code="503" reason="Service Unavailable" />
+                    <set-header name="x-ms-request-id" exists-action="override">
+                        <value>@(context.RequestId.ToString())</value>
+                    </set-header>
+                    <set-header name="Retry-After" exists-action="override">
+                        <value>@(context.Response.Headers.GetValueOrDefault("Retry-After", "60"))</value>
+                    </set-header>
+                    <set-header name="Content-Type" exists-action="override">
+                        <value>application/json</value>
+                    </set-header>
+                    <set-body>@{
+                        var retryAfter = context.Response.Headers.GetValueOrDefault("Retry-After", "60");
+                        return new JObject(
+                            new JProperty("error", new JObject(
+                                new JProperty("code", "503"),
+                                new JProperty("message", "Service temporarily unavailable — backend circuit breaker is open. The service is recovering from excessive failures. Retry after the indicated period."),
+                                new JProperty("retryAfter", retryAfter),
+                                new JProperty("requestId", context.RequestId.ToString())
+                            ))
+                        ).ToString();
+                    }</set-body>
+                </return-response>
+            </when>
             <otherwise>
                 <!-- Return consistent error format with correlation ID -->
+                <!-- Scrub internal backend URLs from error responses to prevent information disclosure -->
                 <return-response>
                     <set-status code="@(context.Response.StatusCode)" reason="@(context.Response.StatusReason)" />
                     <set-header name="x-ms-request-id" exists-action="override">
@@ -102,10 +134,17 @@
                         <value>application/json</value>
                     </set-header>
                     <set-body>@{
+                        var statusCode = context.Response.StatusCode.ToString();
+                        var statusReason = context.Response.StatusReason ?? "Error";
+                        // Scrub internal Azure hostnames from error reason text
+                        statusReason = System.Text.RegularExpressions.Regex.Replace(
+                            statusReason,
+                            @"https?://[a-zA-Z0-9\-]+\.(cognitiveservices\.azure\.com|openai\.azure\.com|search\.windows\.net|blob\.core\.windows\.net|vault\.azure\.net|azure-api\.net)[^\s]*",
+                            "[internal-service]");
                         return new JObject(
                             new JProperty("error", new JObject(
-                                new JProperty("code", context.Response.StatusCode.ToString()),
-                                new JProperty("message", context.Response.StatusReason),
+                                new JProperty("code", statusCode),
+                                new JProperty("message", statusReason),
                                 new JProperty("requestId", context.RequestId.ToString())
                             ))
                         ).ToString();

--- a/infra-ai-hub/params/dev/shared.tfvars
+++ b/infra-ai-hub/params/dev/shared.tfvars
@@ -186,4 +186,5 @@ shared_config = {
     # Keep disabled - access via private endpoint only
     public_network_access_enabled = false
   }
+
 }

--- a/infra-ai-hub/stacks/apim/locals.tf
+++ b/infra-ai-hub/stacks/apim/locals.tf
@@ -77,28 +77,29 @@ locals {
     for key, config in local.enabled_tenants : key => templatefile(
       "${path.root}/../../params/apim/api_policy.xml.tftpl",
       {
-        tenant_name                   = key
-        tokens_per_minute             = try(config.apim_policies.rate_limiting.tokens_per_minute, 10000)
-        model_deployments             = try(config.openai.model_deployments, [])
-        openai_enabled                = length(try(config.openai.model_deployments, [])) > 0
-        document_intelligence_enabled = try(config.document_intelligence.enabled, false)
-        ai_search_enabled             = try(config.ai_search.enabled, false)
-        speech_services_enabled       = try(config.speech_services.enabled, false)
-        storage_enabled               = try(config.storage_account.enabled, false)
-        rate_limiting_enabled         = try(config.apim_policies.rate_limiting.enabled, true)
-        pii_redaction_enabled         = try(config.apim_policies.pii_redaction.enabled, true) && var.shared_config.language_service.enabled
-        usage_logging_enabled         = try(config.apim_policies.usage_logging.enabled, true)
-        streaming_metrics_enabled     = try(config.apim_policies.streaming_metrics.enabled, true)
-        tracking_dimensions_enabled   = try(config.apim_policies.tracking_dimensions.enabled, true)
-        backend_timeout_seconds       = try(config.apim_policies.backend_timeout_seconds, 300)
-        pii_excluded_categories       = try(config.apim_policies.pii_redaction.excluded_categories, [])
-        pii_preserve_json_structure   = try(config.apim_policies.pii_redaction.preserve_json_structure, true)
-        pii_structural_whitelist      = try(config.apim_policies.pii_redaction.structural_whitelist, [])
-        pii_detection_language        = try(config.apim_policies.pii_redaction.detection_language, "en")
-        pii_fail_closed               = try(config.apim_policies.pii_redaction.fail_closed, false)
-        key_rotation_enabled          = local.key_rotation_config.rotation_enabled
-        keyvault_uri                  = local.hub_keyvault_uri
-        tenant_info_enabled           = true
+        tenant_name                    = key
+        tokens_per_minute              = try(config.apim_policies.rate_limiting.tokens_per_minute, 10000)
+        model_deployments              = try(config.openai.model_deployments, [])
+        openai_enabled                 = length(try(config.openai.model_deployments, [])) > 0
+        document_intelligence_enabled  = try(config.document_intelligence.enabled, false)
+        ai_search_enabled              = try(config.ai_search.enabled, false)
+        speech_services_enabled        = try(config.speech_services.enabled, false)
+        storage_enabled                = try(config.storage_account.enabled, false)
+        rate_limiting_enabled          = try(config.apim_policies.rate_limiting.enabled, true)
+        non_openai_requests_per_minute = try(config.apim_policies.rate_limiting.non_openai_requests_per_minute, 300)
+        pii_redaction_enabled          = try(config.apim_policies.pii_redaction.enabled, true) && var.shared_config.language_service.enabled
+        usage_logging_enabled          = try(config.apim_policies.usage_logging.enabled, true)
+        streaming_metrics_enabled      = try(config.apim_policies.streaming_metrics.enabled, true)
+        tracking_dimensions_enabled    = try(config.apim_policies.tracking_dimensions.enabled, true)
+        backend_timeout_seconds        = try(config.apim_policies.backend_timeout_seconds, 300)
+        pii_excluded_categories        = try(config.apim_policies.pii_redaction.excluded_categories, [])
+        pii_preserve_json_structure    = try(config.apim_policies.pii_redaction.preserve_json_structure, true)
+        pii_structural_whitelist       = try(config.apim_policies.pii_redaction.structural_whitelist, [])
+        pii_detection_language         = try(config.apim_policies.pii_redaction.detection_language, "en")
+        pii_fail_closed                = try(config.apim_policies.pii_redaction.fail_closed, false)
+        key_rotation_enabled           = local.key_rotation_config.rotation_enabled
+        keyvault_uri                   = local.hub_keyvault_uri
+        tenant_info_enabled            = true
       }
     )
   }

--- a/infra-ai-hub/stacks/apim/main.tf
+++ b/infra-ai-hub/stacks/apim/main.tf
@@ -163,6 +163,27 @@ resource "azurerm_api_management_backend" "ai_foundry" {
   protocol            = "http"
   url                 = data.terraform_remote_state.shared.outputs.ai_foundry_hub_endpoint
   description         = "Shared AI Foundry Hub backend for all tenant model deployments"
+
+  circuit_breaker_rule {
+    name                       = "ai-foundry-breaker"
+    trip_duration              = "PT1M"
+    accept_retry_after_enabled = true
+
+    failure_condition {
+      count             = 3
+      interval_duration = "PT1M"
+
+      status_code_range {
+        min = 429
+        max = 429
+      }
+
+      status_code_range {
+        min = 500
+        max = 599
+      }
+    }
+  }
 }
 
 resource "azurerm_api_management_backend" "openai" {
@@ -177,6 +198,27 @@ resource "azurerm_api_management_backend" "openai" {
   protocol            = "http"
   url                 = data.terraform_remote_state.shared.outputs.ai_foundry_hub_endpoint
   description         = "OpenAI backend for ${each.value.display_name}"
+
+  circuit_breaker_rule {
+    name                       = "openai-breaker"
+    trip_duration              = "PT1M"
+    accept_retry_after_enabled = true
+
+    failure_condition {
+      count             = 3
+      interval_duration = "PT1M"
+
+      status_code_range {
+        min = 429
+        max = 429
+      }
+
+      status_code_range {
+        min = 500
+        max = 599
+      }
+    }
+  }
 }
 
 resource "azurerm_api_management_backend" "docint" {
@@ -191,6 +233,27 @@ resource "azurerm_api_management_backend" "docint" {
   protocol            = "http"
   url                 = data.terraform_remote_state.tenant[each.key].outputs.tenant_document_intelligence[each.key].endpoint
   description         = "Document Intelligence backend for ${each.value.display_name}"
+
+  circuit_breaker_rule {
+    name                       = "docint-breaker"
+    trip_duration              = "PT1M"
+    accept_retry_after_enabled = true
+
+    failure_condition {
+      count             = 3
+      interval_duration = "PT1M"
+
+      status_code_range {
+        min = 429
+        max = 429
+      }
+
+      status_code_range {
+        min = 500
+        max = 599
+      }
+    }
+  }
 }
 
 resource "azurerm_api_management_backend" "storage" {
@@ -205,6 +268,27 @@ resource "azurerm_api_management_backend" "storage" {
   protocol            = "http"
   url                 = data.terraform_remote_state.tenant[each.key].outputs.tenant_storage_accounts[each.key].blob_endpoint
   description         = "Storage backend for ${each.value.display_name}"
+
+  circuit_breaker_rule {
+    name                       = "storage-breaker"
+    trip_duration              = "PT1M"
+    accept_retry_after_enabled = true
+
+    failure_condition {
+      count             = 5
+      interval_duration = "PT1M"
+
+      status_code_range {
+        min = 429
+        max = 429
+      }
+
+      status_code_range {
+        min = 500
+        max = 599
+      }
+    }
+  }
 }
 
 resource "azurerm_api_management_backend" "ai_search" {
@@ -219,6 +303,27 @@ resource "azurerm_api_management_backend" "ai_search" {
   protocol            = "http"
   url                 = data.terraform_remote_state.tenant[each.key].outputs.tenant_ai_search[each.key].endpoint
   description         = "AI Search backend for ${each.value.display_name}"
+
+  circuit_breaker_rule {
+    name                       = "ai-search-breaker"
+    trip_duration              = "PT1M"
+    accept_retry_after_enabled = true
+
+    failure_condition {
+      count             = 3
+      interval_duration = "PT1M"
+
+      status_code_range {
+        min = 429
+        max = 429
+      }
+
+      status_code_range {
+        min = 500
+        max = 599
+      }
+    }
+  }
 }
 
 resource "azurerm_api_management_backend" "speech_services_stt" {
@@ -233,6 +338,27 @@ resource "azurerm_api_management_backend" "speech_services_stt" {
   protocol            = "http"
   url                 = data.terraform_remote_state.tenant[each.key].outputs.tenant_speech_services[each.key].endpoint
   description         = "Speech-to-text backend for ${each.value.display_name}"
+
+  circuit_breaker_rule {
+    name                       = "speech-stt-breaker"
+    trip_duration              = "PT1M"
+    accept_retry_after_enabled = true
+
+    failure_condition {
+      count             = 3
+      interval_duration = "PT1M"
+
+      status_code_range {
+        min = 429
+        max = 429
+      }
+
+      status_code_range {
+        min = 500
+        max = 599
+      }
+    }
+  }
 }
 
 resource "azurerm_api_management_backend" "speech_services_tts" {
@@ -247,6 +373,27 @@ resource "azurerm_api_management_backend" "speech_services_tts" {
   protocol            = "http"
   url                 = data.terraform_remote_state.tenant[each.key].outputs.tenant_speech_services[each.key].endpoint
   description         = "Text-to-speech backend for ${each.value.display_name}"
+
+  circuit_breaker_rule {
+    name                       = "speech-tts-breaker"
+    trip_duration              = "PT1M"
+    accept_retry_after_enabled = true
+
+    failure_condition {
+      count             = 3
+      interval_duration = "PT1M"
+
+      status_code_range {
+        min = 429
+        max = 429
+      }
+
+      status_code_range {
+        min = 500
+        max = 599
+      }
+    }
+  }
 }
 
 resource "azurerm_api_management_named_value" "speech_services_key" {


### PR DESCRIPTION


<!-- ai-hub-infra-changes -->
## AI Hub Infra Changes

**Summary:** 1 to add, 32 to change, 1 to destroy (across 2 stack(s))

<details><summary>Show plan details</summary>

```hcl
Terraform will perform the following actions:

  # module.hub_key_vault.azurerm_role_assignment.this["deployer_secrets_officer"] must be replaced
-/+ resource "azurerm_role_assignment" "this" {
      + condition_version                      = (known after apply)
      ~ id                                     = "/subscriptions/****/resourceGroups/ai-services-hub-test/providers/Microsoft.KeyVault/vaults/ai-services-hub-test-hkv/providers/Microsoft.Authorization/roleAssignments/****" -> (known after apply)
      ~ name                                   = "****" -> (known after apply)
      ~ principal_id                           = "****" -> "****" # forces replacement
      ~ principal_type                         = "User" -> (known after apply)
      ~ role_definition_id                     = "/subscriptions/****/providers/Microsoft.Authorization/roleDefinitions/****" -> (known after apply)
        # (6 unchanged attributes hidden)
    }

Plan: 1 to add, 0 to change, 1 to destroy.

Warning: Argument is deprecated

  with module.hub_key_vault.azurerm_key_vault.this,
  on .terraform/modules/hub_key_vault/main.tf line 7, in resource "azurerm_key_vault" "this":
   7:   enable_rbac_authorization       = !var.legacy_access_policies_enabled

This property has been renamed to `rbac_authorization_enabled` and will be
removed in v5.0 of the provider

─────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't
guarantee to take exactly these actions if you run "terraform apply" now.
Releasing state lock. This may take a few moments...
2026-02-23T01:58:44Z [SUCCESS] terraform plan (shared) (attempt 1/5) completed successfully
2026-02-23T01:58:47Z [INFO] Running 3 tenants in parallel
2026-02-23T01:58:47Z [INFO] Starting terraform init (tenant:nr-dap-fish-wildlife)
2026-02-23T01:58:47.149Z [INFO]  Terraform version: 1.12.2
2026-02-23T01:58:47.149Z [INFO]  Go runtime version: go1.24.2
2026-02-23T01:58:47.149Z [INFO]  CLI args: []string{"terraform", "init", "-input=false", "-upgrade", "-reconfigure", "-backend-config=resource_group_name=da4cf6-test-networking", "-backend-config=storage_account_name=tftestaihubtracking", "-backend-config=container_name=tfstate", "-backend-config=key=ai-services-hub/test/tenant-nr-dap-fish-wildlife.tfstate", "-backend-config=subscription_id=****", "-backend-config=tenant_id=****", "-backend-config=client_id=****", "-backend-config=use_oidc=true"}
2026-02-23T01:58:47.149Z [INFO]  TF_CLI_ARGS value: "-no-color"
2026-02-23T01:58:47.150Z [INFO]  CLI command args: []string{"init", "-no-color", "-input=false", "-upgrade", "-reconfigure", "-backend-config=resource_group_name=da4cf6-test-networking", "-backend-config=storage_account_name=tftestaihubtracking", "-backend-config=container_name=tfstate", "-backend-config=key=ai-services-hub/test/tenant-nr-dap-fish-wildlife.tfstate", "-backend-config=subscription_id=****", "-backend-config=tenant_id=****", "-backend-config=client_id=****", "-backend-config=use_oidc=true"}
Initializing the backend...

Successfully configured the backend "azurerm"! Terraform will automatically
use this backend unless the backend configuration changes.
Upgrading modules...
- tenant in ../../modules/tenant
Downloading registry.terraform.io/Azure/avm-res-search-searchservice/azurerm 0.2.0 for tenant.ai_search...
- tenant.ai_search in /home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-nr-dap-fish-wildlife/modules/tenant.ai_search
Downloading registry.terraform.io/Azure/avm-res-cognitiveservices-account/azurerm 0.6.0 for tenant.document_intelligence...
- tenant.document_intelligence in /home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-nr-dap-fish-wildlife/modules/tenant.document_intelligence
Downloading registry.terraform.io/Azure/avm-res-keyvault-vault/azurerm 0.10.2 for tenant.key_vault...
- tenant.key_vault in /home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-nr-dap-fish-wildlife/modules/tenant.key_vault
- tenant.key_vault.keys in /home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-nr-dap-fish-wildlife/modules/tenant.key_vault/modules/key
- tenant.key_vault.secrets in /home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-nr-dap-fish-wildlife/modules/tenant.key_vault/modules/secret
Downloading registry.terraform.io/Azure/avm-res-cognitiveservices-account/azurerm 0.6.0 for tenant.speech_services...
- tenant.speech_services in /home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-nr-dap-fish-wildlife/modules/tenant.speech_services
Initializing provider plugins...
- terraform.io/builtin/terraform is built in to Terraform
- Finding hashicorp/random versions matching ">= 3.5.0, ~> 3.5, >= 3.7.0"...
- Finding hashicorp/null versions matching ">= 3.2.0"...
- Finding azure/modtm versions matching "~> 0.3, >= 0.3.2, < 1.0.0"...
- Finding hashicorp/time versions matching "~> 0.9"...
- Finding hashicorp/azurerm versions matching ">= 3.117.0, ~> 4.0, >= 4.38.0, < 5.0.0"...
- Finding azure/azapi versions matching "~> 2.0, ~> 2.4, >= 2.5.0"...
- Installing azure/azapi v2.8.0...
- Installed azure/azapi v2.8.0 (signed by a HashiCorp partner, key ID 6F0B91BDE98478CF)
- Installing hashicorp/random v3.8.1...
- Installed hashicorp/random v3.8.1 (signed by HashiCorp)
- Installing hashicorp/null v3.2.4...
- Installed hashicorp/null v3.2.4 (signed by HashiCorp)
- Installing azure/modtm v0.3.5...
- Installed azure/modtm v0.3.5 (signed by a HashiCorp partner, key ID 6F0B91BDE98478CF)
- Installing hashicorp/time v0.13.1...
- Installed hashicorp/time v0.13.1 (signed by HashiCorp)
- Installing hashicorp/azurerm v4.61.0...
- Installed hashicorp/azurerm v4.61.0 (signed by HashiCorp)
Partner and community providers are signed by their developers.
If you'd like to know more about provider signing, you can read about it here:
https://developer.hashicorp.com/terraform/cli/plugins/signing
Terraform has created a lock file .terraform.lock.hcl to record the provider
selections it made above. Include this file in your version control repository
so that Terraform can guarantee to make the same selections by default when
you run "terraform init" in the future.

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
2026-02-23T01:59:00Z [SUCCESS] terraform init (tenant:nr-dap-fish-wildlife) completed successfully
2026-02-23T01:59:00Z [INFO] Starting terraform plan (tenant:nr-dap-fish-wildlife) (attempt 1/5)
2026-02-23T01:59:00.496Z [INFO]  Terraform version: 1.12.2
2026-02-23T01:59:00.496Z [INFO]  Go runtime version: go1.24.2
2026-02-23T01:59:00.496Z [INFO]  CLI args: []string{"terraform", "plan", "-input=false", "-var-file=/home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/params/test/shared.tfvars", "-var-file=/home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.tenant-test-nr-dap-fish-wildlife.auto.tfvars", "-var=backend_resource_group=da4cf6-test-networking", "-var=backend_storage_account=tftestaihubtracking", "-var=backend_container_name=tfstate", "-var=app_env=test"}
2026-02-23T01:59:00.497Z [INFO]  TF_CLI_ARGS value: "-no-color"
2026-02-23T01:59:00.497Z [INFO]  CLI command args: []string{"plan", "-no-color", "-input=false", "-var-file=/home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/params/test/shared.tfvars", "-var-file=/home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.tenant-test-nr-dap-fish-wildlife.auto.tfvars", "-var=backend_resource_group=da4cf6-test-networking", "-var=backend_storage_account=tftestaihubtracking", "-var=backend_container_name=tfstate", "-var=app_env=test"}
2026-02-23T01:59:01.883Z [INFO]  backend/local: starting Plan operation
Acquiring state lock. This may take a few moments...
2026-02-23T01:59:05.006Z [INFO]  provider: configuring client automatic mTLS
2026-02-23T01:59:05.025Z [INFO]  provider.terraform-provider-azapi_v2.8.0: configuring server automatic mTLS: timestamp=2026-02-23T01:59:05.023Z
2026-02-23T01:59:05.075Z [INFO]  provider: plugin process exited: plugin=/home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-nr-dap-fish-wildlife/providers/registry.terraform.io/azure/azapi/2.8.0/linux_amd64/terraform-provider-azapi_v2.8.0 id=3860
2026-02-23T01:59:05.076Z [INFO]  provider: configuring client automatic mTLS
2026-02-23T01:59:05.087Z [INFO]  provider.terraform-provider-modtm_v0.3.5: configuring server automatic mTLS: timestamp=2026-02-23T01:59:05.087Z
2026-02-23T01:59:05.126Z [INFO]  provider: plugin process exited: plugin=/home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-nr-dap-fish-wildlife/providers/registry.terraform.io/azure/modtm/0.3.5/linux_amd64/terraform-provider-modtm_v0.3.5 id=3869
2026-02-23T01:59:05.126Z [INFO]  provider: configuring client automatic mTLS
2026-02-23T01:59:05.240Z [INFO]  provider.terraform-provider-azurerm_v4.61.0_x5: configuring server automatic mTLS: timestamp=2026-02-23T01:59:05.240Z
2026-02-23T01:59:05.568Z [INFO]  provider: plugin process exited: plugin=/home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-nr-dap-fish-wildlife/providers/registry.terraform.io/hashicorp/azurerm/4.61.0/linux_amd64/terraform-provider-azurerm_v4.61.0_x5 id=3877
2026-02-23T01:59:05.568Z [INFO]  provider: configuring client automatic mTLS
2026-02-23T01:59:05.579Z [INFO]  provider.terraform-provider-null_v3.2.4_x5: configuring server automatic mTLS: timestamp=2026-02-23T01:59:05.579Z
2026-02-23T01:59:05.620Z [INFO]  provider: plugin process exited: plugin=/home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-nr-dap-fish-wildlife/providers/registry.terraform.io/hashicorp/null/3.2.4/linux_amd64/terraform-provider-null_v3.2.4_x5 id=3910
2026-02-23T01:59:05.620Z [INFO]  provider: configuring client automatic mTLS
2026-02-23T01:59:05.632Z [INFO]  provider.terraform-provider-random_v3.8.1_x5: configuring server automatic mTLS: timestamp=2026-02-23T01:59:05.632Z
2026-02-23T01:59:05.663Z [INFO]  provider: plugin process exited: plugin=/home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-nr-dap-fish-wildlife/providers/registry.terraform.io/hashicorp/random/3.8.1/linux_amd64/terraform-provider-random_v3.8.1_x5 id=3923
2026-02-23T01:59:05.663Z [INFO]  provider: configuring client automatic mTLS
2026-02-23T01:59:05.676Z [INFO]  provider.terraform-provider-time_v0.13.1_x5: configuring server automatic mTLS: timestamp=2026-02-23T01:59:05.676Z
2026-02-23T01:59:05.711Z [INFO]  provider: plugin process exited: plugin=/home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-nr-dap-fish-wildlife/providers/registry.terraform.io/hashicorp/time/0.13.1/linux_amd64/terraform-provider-time_v0.13.1_x5 id=3940
2026-02-23T01:59:05.729Z [ERROR] AttachSchemaTransformer: No provider config schema available for provider["terraform.io/builtin/terraform"]
2026-02-23T01:59:05.819Z [INFO]  provider: configuring client automatic mTLS
2026-02-23T01:59:05.831Z [INFO]  provider.terraform-provider-null_v3.2.4_x5: configuring server automatic mTLS: timestamp=2026-02-23T01:59:05.831Z
2026-02-23T01:59:05.860Z [INFO]  provider: configuring client automatic mTLS
2026-02-23T01:59:05.869Z [INFO]  provider.terraform-provider-modtm_v0.3.5: configuring server automatic mTLS: timestamp=2026-02-23T01:59:05.869Z
2026-02-23T01:59:05.894Z [INFO]  provider: configuring client autom
(truncated, see workflow logs for complete plan)
```

</details>

---
_Updated by CI — plan against `test` environment (run [#196](https://github.com/bcgov/ai-hub-tracking/actions/runs/22290281440))._
<!-- /ai-hub-infra-changes -->