### PR TITLE
fix: routing from bcgov internal systems

### DIFF
--- a/infra-ai-hub/modules/network/main.tf
+++ b/infra-ai-hub/modules/network/main.tf
@@ -354,6 +354,17 @@ resource "azurerm_route" "appgw_internet" {
   address_prefix = "0.0.0.0/0"
   next_hop_type  = "Internet"
 }
+## this is needed to avoid asymetric routing due to express route.
+resource "azurerm_route" "appgw_bcgov_internal" {
+  count = var.appgw_subnet.enabled ? 1 : 0
+
+  name                = "bcgov-internal"
+  resource_group_name = var.vnet_resource_group_name
+  route_table_name    = azurerm_route_table.appgw[0].name
+
+  address_prefix = "142.34.0.0/16"
+  next_hop_type  = "Internet"
+}
 
 resource "azapi_resource" "appgw_subnet" {
   count = var.appgw_subnet.enabled ? 1 : 0


### PR DESCRIPTION


<!-- ai-hub-infra-changes -->
## AI Hub Infra Changes

**Summary:** 2 to add, 32 to change, 1 to destroy (across 2 stack(s))

<details><summary>Show plan details</summary>

```hcl
Terraform will perform the following actions:

  # module.ai_foundry_hub.data.azurerm_client_config.current will be read during apply
  # (depends on a resource or a module with changes pending)
 <= data "azurerm_client_config" "current" {
      + client_id       = (known after apply)
      + id              = (known after apply)
      + object_id       = (known after apply)
      + subscription_id = (known after apply)
      + tenant_id       = (known after apply)
    }

  # module.ai_foundry_hub.null_resource.purge_ai_foundry[0] must be replaced
-/+ resource "null_resource" "purge_ai_foundry" {
      ~ id       = "1160787096066186980" -> (known after apply)
      ~ triggers = { # forces replacement
          ~ "subscription_id"     = "****" -> (known after apply)
            # (6 unchanged elements hidden)
        }
    }

  # module.network.azurerm_route.appgw_bcgov_internal[0] will be created
  + resource "azurerm_route" "appgw_bcgov_internal" {
      + address_prefix      = "142.34.0.0/16"
      + id                  = (known after apply)
      + name                = "bcgov-internal"
      + next_hop_type       = "Internet"
      + resource_group_name = "da4cf6-test-networking"
      + route_table_name    = "ai-services-hub-test-appgw-rt"
    }

Plan: 2 to add, 0 to change, 1 to destroy.

Warning: Argument is deprecated

  with module.hub_key_vault.azurerm_key_vault.this,
  on .terraform/modules/hub_key_vault/main.tf line 7, in resource "azurerm_key_vault" "this":
   7:   enable_rbac_authorization       = !var.legacy_access_policies_enabled

This property has been renamed to `rbac_authorization_enabled` and will be
removed in v5.0 of the provider

─────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't
guarantee to take exactly these actions if you run "terraform apply" now.
Releasing state lock. This may take a few moments...
2026-02-23T23:55:48Z [SUCCESS] terraform plan (shared) (attempt 1/5) completed successfully
2026-02-23T23:55:50Z [INFO] Running 3 tenants in parallel
2026-02-23T23:55:50Z [INFO] Starting terraform init (tenant:nr-dap-fish-wildlife)
2026-02-23T23:55:50.366Z [INFO]  Terraform version: 1.12.2
2026-02-23T23:55:50.367Z [INFO]  Go runtime version: go1.24.2
2026-02-23T23:55:50.367Z [INFO]  CLI args: []string{"terraform", "init", "-input=false", "-upgrade", "-reconfigure", "-backend-config=resource_group_name=da4cf6-test-networking", "-backend-config=storage_account_name=tftestaihubtracking", "-backend-config=container_name=tfstate", "-backend-config=key=ai-services-hub/test/tenant-nr-dap-fish-wildlife.tfstate", "-backend-config=subscription_id=****", "-backend-config=tenant_id=****", "-backend-config=client_id=****", "-backend-config=use_oidc=true"}
2026-02-23T23:55:50.367Z [INFO]  TF_CLI_ARGS value: "-no-color"
2026-02-23T23:55:50.367Z [INFO]  CLI command args: []string{"init", "-no-color", "-input=false", "-upgrade", "-reconfigure", "-backend-config=resource_group_name=da4cf6-test-networking", "-backend-config=storage_account_name=tftestaihubtracking", "-backend-config=container_name=tfstate", "-backend-config=key=ai-services-hub/test/tenant-nr-dap-fish-wildlife.tfstate", "-backend-config=subscription_id=****", "-backend-config=tenant_id=****", "-backend-config=client_id=****", "-backend-config=use_oidc=true"}
Initializing the backend...

Successfully configured the backend "azurerm"! Terraform will automatically
use this backend unless the backend configuration changes.
Upgrading modules...
- tenant in ../../modules/tenant
Downloading registry.terraform.io/Azure/avm-res-search-searchservice/azurerm 0.2.0 for tenant.ai_search...
- tenant.ai_search in /home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-nr-dap-fish-wildlife/modules/tenant.ai_search
Downloading registry.terraform.io/Azure/avm-res-cognitiveservices-account/azurerm 0.6.0 for tenant.document_intelligence...
- tenant.document_intelligence in /home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-nr-dap-fish-wildlife/modules/tenant.document_intelligence
Downloading registry.terraform.io/Azure/avm-res-keyvault-vault/azurerm 0.10.2 for tenant.key_vault...
- tenant.key_vault in /home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-nr-dap-fish-wildlife/modules/tenant.key_vault
- tenant.key_vault.keys in /home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-nr-dap-fish-wildlife/modules/tenant.key_vault/modules/key
- tenant.key_vault.secrets in /home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-nr-dap-fish-wildlife/modules/tenant.key_vault/modules/secret
Downloading registry.terraform.io/Azure/avm-res-cognitiveservices-account/azurerm 0.6.0 for tenant.speech_services...
- tenant.speech_services in /home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-nr-dap-fish-wildlife/modules/tenant.speech_services
Initializing provider plugins...
- terraform.io/builtin/terraform is built in to Terraform
- Finding azure/modtm versions matching "~> 0.3, >= 0.3.2, < 1.0.0"...
- Finding hashicorp/time versions matching "~> 0.9"...
- Finding hashicorp/azurerm versions matching ">= 3.117.0, ~> 4.0, >= 4.38.0, < 5.0.0"...
- Finding azure/azapi versions matching "~> 2.0, ~> 2.4, >= 2.5.0"...
- Finding hashicorp/random versions matching ">= 3.5.0, ~> 3.5, >= 3.7.0"...
- Finding hashicorp/null versions matching ">= 3.2.0"...
- Installing azure/azapi v2.8.0...
- Installed azure/azapi v2.8.0 (signed by a HashiCorp partner, key ID 6F0B91BDE98478CF)
- Installing hashicorp/random v3.8.1...
- Installed hashicorp/random v3.8.1 (signed by HashiCorp)
- Installing hashicorp/null v3.2.4...
- Installed hashicorp/null v3.2.4 (signed by HashiCorp)
- Installing azure/modtm v0.3.5...
- Installed azure/modtm v0.3.5 (signed by a HashiCorp partner, key ID 6F0B91BDE98478CF)
- Installing hashicorp/time v0.13.1...
- Installed hashicorp/time v0.13.1 (signed by HashiCorp)
- Installing hashicorp/azurerm v4.61.0...
- Installed hashicorp/azurerm v4.61.0 (signed by HashiCorp)
Partner and community providers are signed by their developers.
If you'd like to know more about provider signing, you can read about it here:
https://developer.hashicorp.com/terraform/cli/plugins/signing
Terraform has created a lock file .terraform.lock.hcl to record the provider
selections it made above. Include this file in your version control repository
so that Terraform can guarantee to make the same selections by default when
you run "terraform init" in the future.

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
2026-02-23T23:55:58Z [SUCCESS] terraform init (tenant:nr-dap-fish-wildlife) completed successfully
2026-02-23T23:55:58Z [INFO] Starting terraform plan (tenant:nr-dap-fish-wildlife) (attempt 1/5)
2026-02-23T23:55:58.790Z [INFO]  Terraform version: 1.12.2
2026-02-23T23:55:58.790Z [INFO]  Go runtime version: go1.24.2
2026-02-23T23:55:58.790Z [INFO]  CLI args: []string{"terraform", "plan", "-input=false", "-var-file=/home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/params/test/shared.tfvars", "-var-file=/home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.tenant-test-nr-dap-fish-wildlife.auto.tfvars", "-var=backend_resource_group=da4cf6-test-networking", "-var=backend_storage_account=tftestaihubtracking", "-var=backend_container_name=tfstate", "-var=app_env=test"}
2026-02-23T23:55:58.791Z [INFO]  TF_CLI_ARGS value: "-no-color"
2026-02-23T23:55:58.791Z [INFO]  CLI command args: []string{"plan", "-no-color", "-input=false", "-var-file=/home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/params/test/shared.tfvars", "-var-file=/home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.tenant-test-nr-dap-fish-wildlife.auto.tfvars", "-var=backend_resource_group=da4cf6-test-networking", "-var=backend_storage_account=tftestaihubtracking", "-var=backend_container_name=tfstate", "-var=app_env=test"}
2026-02-23T23:55:59.900Z [INFO]  backend/local: starting Plan operation
Acquiring state lock. This may take a few moments...
2026-02-23T23:56:00.890Z [INFO]  provider: configuring client automatic mTLS
2026-02-23T23:56:00.900Z [INFO]  provider.terraform-provider-azapi_v2.8.0: configuring server automatic mTLS: timestamp=2026-02-23T23:56:00.900Z
2026-02-23T23:56:00.930Z [INFO]  provider: plugin process exited: plugin=/home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-nr-dap-fish-wildlife/providers/registry.terraform.io/azure/azapi/2.8.0/linux_amd64/terraform-provider-azapi_v2.8.0 id=3641
2026-02-23T23:56:00.931Z [INFO]  provider: configuring client automatic mTLS
2026-02-23T23:56:00.942Z [INFO]  provider.terraform-provider-modtm_v0.3.5: configuring server automatic mTLS: timestamp=2026-02-23T23:56:00.942Z
2026-02-23T23:56:00.975Z [INFO]  provider: plugin process exited: plugin=/home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-nr-dap-fish-wildlife/providers/registry.terraform.io/azure/modtm/0.3.5/linux_amd64/terraform-provider-modtm_v0.3.5 id=3650
2026-02-23T23:56:00.976Z [INFO]  provider: configuring client automatic mTLS
2026-02-23T23:56:01.082Z [INFO]  provider.terraform-provider-azurerm_v4.61.0_x5: configuring server automatic mTLS: timestamp=2026-02-23T23:56:01.082Z
2026-02-23T23:56:01.470Z [INFO]  provider: plugin process exited: plugin=/home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-nr-dap-fish-wildlife/providers/registry.terraform.io/hashicorp/azurerm/4.61.0/linux_amd64/terraform-provider-azurerm_v4.61.0_x5 id=3661
2026-02-23T23:56:01.470Z [INFO]  provider: configuring client automatic mTLS
2026-02-23T23:56:01.483Z [INFO]  provider.terraform-provider-null_v3.2.4_x5: configuring server automatic mTLS: timestamp=2026-02-23T23:56:01.483Z
2026-02-23T23:56:01.520Z [INFO]  provider: plugin process exited: plugin=/home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-nr-dap-fish-wildlife/providers/registry.terraform.io/hashicorp/null/3.2.4/linux_amd64/terraform-provider-null_v3.2.4_x5 id=3725
2026-02-23T23:56:01.520Z [INFO]  provider: configuring client automatic mTLS
2026-02-23T23:56:01.533Z [INFO]  provider.terraform-provider-random_v3.8.1_x5: configuring server automatic mTLS: timestamp=2026-02-23T23:56:01.533Z
2026-02-23T23:56:01.573Z [INFO]  provider: plugin process exited: plugin=/home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-nr-dap-fish-wildlife/providers/registry.terraform.io/hashicorp/random/3.8.1/linux_amd64/terraform-provider-random_v3.8.1_x5 id=3734
2026-02-23T23:56:01.573Z [INFO]  provider: configuring client automatic mTLS
2026-02-23T23:56:01.589Z [INFO]  provider.terraform-provider-time_v0.13.1_x5: configuring server automatic mTLS: timestamp=2026-02-23T23:56:01.589Z
2026-02-23T23:56:01.631Z [INFO]  provider: plugin process exited: plugin=/home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-nr-dap-fish-wildlife/providers/registry.terraform.io/hashicorp/time/0.13.1/linux_amd64/terraform-provider-time_v0.13.1_x5 id=3743
2026-02-23T23:56:01.647Z [ERROR] AttachSchemaTransformer: No provider config schema available for provider["terraform.io/builtin/terraform"]
2026-02-23T23:56:01.754Z [INFO]  provider: configuring client automatic mTLS
2026-02-23T23:56:01.783Z [INFO]  provider.terraform-provider-modtm_v0.3.5: configuring server automatic mTLS: timest
(truncated, see workflow logs for complete plan)
```

</details>

---
_Updated by CI — plan against `test` environment (run [#197](https://github.com/bcgov/ai-hub-tracking/actions/runs/22329167515))._
<!-- /ai-hub-infra-changes -->