### PR TITLE
Use Language Service API v2024-11-01

### DIFF
--- a/docs/_pages/language-service-pii.html
+++ b/docs/_pages/language-service-pii.html
@@ -63,7 +63,7 @@
     <li>The fragment:
         <ul>
             <li>Obtains an AAD token via <code>&lt;authentication-managed-identity&gt;</code> for <code>https://cognitiveservices.azure.com</code>.</li>
-            <li>Calls Language Service <code>/language/:analyze-text?api-version=2025-11-15-preview</code> with request kind <code>PiiEntityRecognition</code>.</li>
+            <li>Calls Language Service <code>/language/:analyze-text?api-version=2024-11-01</code> with request kind <code>PiiEntityRecognition</code>.</li>
             <li>Uses a CharacterMask redaction policy (mask character <code>#</code>).</li>
             <li>Extracts <code>results.documents[0].redactedText</code> into <code>piiAnonymizedContent</code>.</li>
             <li>Emits diagnostics including status code, entity count, entity types, and whether content changed.</li>

--- a/docs/language-service-pii.html
+++ b/docs/language-service-pii.html
@@ -1141,7 +1141,7 @@
     <li>The fragment:
         <ul>
             <li>Obtains an AAD token via <code>&lt;authentication-managed-identity&gt;</code> for <code>https://cognitiveservices.azure.com</code>.</li>
-            <li>Calls Language Service <code>/language/:analyze-text?api-version=2025-11-15-preview</code> with request kind <code>PiiEntityRecognition</code>.</li>
+            <li>Calls Language Service <code>/language/:analyze-text?api-version=2024-11-01</code> with request kind <code>PiiEntityRecognition</code>.</li>
             <li>Uses a CharacterMask redaction policy (mask character <code>#</code>).</li>
             <li>Extracts <code>results.documents[0].redactedText</code> into <code>piiAnonymizedContent</code>.</li>
             <li>Emits diagnostics including status code, entity count, entity types, and whether content changed.</li>

--- a/infra-ai-hub/params/apim/README.md
+++ b/infra-ai-hub/params/apim/README.md
@@ -392,11 +392,11 @@ Detect and mask PII in text content using Language Service PII entity recognitio
 - Deletes any `api-key` header
 
 **API Call:**
-- Endpoint: `{{piiServiceUrl}}/language/:analyze-text?api-version=2025-11-15-preview`
+- Endpoint: `{{piiServiceUrl}}/language/:analyze-text?api-version=2024-11-01`
 - Method: `POST`
 - Timeout: `20` seconds
 - `ignore-error="true"` (errors are handled with fallback behavior)
-- API version `2025-11-15-preview` is documented at [Microsoft Learn: PII Detection](https://learn.microsoft.com/en-us/azure/ai-services/language-service/personally-identifiable-information/overview)
+- API version `2024-11-01` (GA) is documented at [Microsoft Learn: PII Detection](https://learn.microsoft.com/en-us/azure/ai-services/language-service/personally-identifiable-information/overview)
 
 **Request Body (high level):**
 - `kind`: `PiiEntityRecognition`

--- a/infra-ai-hub/params/apim/fragments/pii-anonymization.xml
+++ b/infra-ai-hub/params/apim/fragments/pii-anonymization.xml
@@ -162,7 +162,7 @@
 
             <!-- Call Azure Language Service PII API with per-message documents -->
             <send-request mode="new" response-variable-name="piiAnalysisResponse" timeout="20" ignore-error="true">
-                <set-url>{{piiServiceUrl}}/language/:analyze-text?api-version=2025-11-15-preview</set-url>
+                <set-url>{{piiServiceUrl}}/language/:analyze-text?api-version=2024-11-01</set-url>
                 <set-method>POST</set-method>
                 <set-header name="Content-Type" exists-action="override">
                     <value>application/json</value>


### PR DESCRIPTION
Replace Language Service PII endpoint API version 2025-11-15-preview with the GA 2024-11-01 across documentation and APIM config. Updated docs/_pages/language-service-pii.html, docs/language-service-pii.html, infra-ai-hub/params/apim/README.md, and infra-ai-hub/params/apim/fragments/pii-anonymization.xml to call the GA version and adjust the README reference accordingly.