### PR TITLE
fix(tests): fix jq scoping in tenant-info azure_openai url test

### DIFF
--- a/tests/integration/tenant-info.bats
+++ b/tests/integration/tenant-info.bats
@@ -547,8 +547,8 @@ post_tenant_info() {
     # For each model, the azure_openai URL must contain /deployments/{model.name}/
     local mismatch_count
     mismatch_count=$(echo "${RESPONSE_BODY}" | jq '[
-        .models[] | select(
-            (.endpoints.azure_openai.url | contains("/deployments/" + .name + "/")) | not
+        .models[] | . as $m | select(
+            ($m.endpoints.azure_openai.url | contains("/deployments/" + $m.name + "/")) | not
         )
     ] | length')
     [[ "${mismatch_count}" -eq 0 ]]


### PR DESCRIPTION


<!-- ai-hub-infra-changes -->
## AI Hub Infra Changes

No Changes to AI Hub Infra in this PR

---
_Updated by CI — plan against `test` environment (run [#218](https://github.com/bcgov/ai-hub-tracking/actions/runs/22513138217))._
<!-- /ai-hub-infra-changes -->