### PR TITLE
fix: increase app gw timeout to 240 seconds

### DIFF
--- a/infra-ai-hub/modules/app-gateway/main.tf
+++ b/infra-ai-hub/modules/app-gateway/main.tf
@@ -105,7 +105,7 @@ resource "azurerm_application_gateway" "this" {
     port                                = var.backend_apim.https_port
     protocol                            = "Https"
     cookie_based_affinity               = "Disabled"
-    request_timeout                     = 30
+    request_timeout                     = 240
     pick_host_name_from_backend_address = true
     probe_name                          = local.probe_name
   }


### PR DESCRIPTION


<!-- ai-hub-infra-changes -->
## AI Hub Infra Changes

**Summary:** 1 to add, 15 to change, 0 to destroy (across 3 stack(s))

<details><summary>Show plan details</summary>

```hcl
Terraform will perform the following actions:

  # module.app_gateway[0].azurerm_application_gateway.this will be updated in-place
  ~ resource "azurerm_application_gateway" "this" {
        id                                = "/subscriptions/****/resourceGroups/ai-services-hub-test/providers/Microsoft.Network/applicationGateways/ai-services-hub-test-appgw"
        name                              = "ai-services-hub-test-appgw"
        tags                              = {
            "app_env"     = "test"
            "environment" = "test"
            "repo_name"   = "ai-hub-tracking"
        }
        # (9 unchanged attributes hidden)

      - backend_http_settings {
          - cookie_based_affinity                = "Disabled" -> null
          - dedicated_backend_connection_enabled = false -> null
          - id                                   = "/subscriptions/****/resourceGroups/ai-services-hub-test/providers/Microsoft.Network/applicationGateways/ai-services-hub-test-appgw/backendHttpSettingsCollection/ai-services-hub-test-appgw-httpsetting" -> null
          - name                                 = "ai-services-hub-test-appgw-httpsetting" -> null
          - pick_host_name_from_backend_address  = true -> null
          - port                                 = 443 -> null
          - probe_id                             = "/subscriptions/****/resourceGroups/ai-services-hub-test/providers/Microsoft.Network/applicationGateways/ai-services-hub-test-appgw/probes/ai-services-hub-test-appgw-probe-apim" -> null
          - probe_name                           = "ai-services-hub-test-appgw-probe-apim" -> null
          - protocol                             = "Https" -> null
          - request_timeout                      = 30 -> null
          - trusted_root_certificate_names       = [] -> null
            # (3 unchanged attributes hidden)
        }
      + backend_http_settings {
          + cookie_based_affinity                = "Disabled"
          + dedicated_backend_connection_enabled = false
          + id                                   = (known after apply)
          + name                                 = "ai-services-hub-test-appgw-httpsetting"
          + pick_host_name_from_backend_address  = true
          + port                                 = 443
          + probe_id                             = (known after apply)
          + probe_name                           = "ai-services-hub-test-appgw-probe-apim"
          + protocol                             = "Https"
          + request_timeout                      = 240
          + trusted_root_certificate_names       = []
            # (3 unchanged attributes hidden)
        }

        # (17 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Warning: Argument is deprecated

  with module.hub_key_vault.azurerm_key_vault.this,
  on .terraform/modules/hub_key_vault/main.tf line 7, in resource "azurerm_key_vault" "this":
   7:   enable_rbac_authorization       = !var.legacy_access_policies_enabled

This property has been renamed to `rbac_authorization_enabled` and will be
removed in v5.0 of the provider

─────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't
guarantee to take exactly these actions if you run "terraform apply" now.
Releasing state lock. This may take a few moments...
2026-03-09T18:50:35Z [SUCCESS] terraform plan (shared) (attempt 1/5) completed successfully
2026-03-09T18:50:37Z [INFO] Running 5 tenants in parallel
2026-03-09T18:50:37Z [INFO] Starting terraform init (tenant:ai-hub-admin)
Initializing the backend...

Successfully configured the backend "azurerm"! Terraform will automatically
use this backend unless the backend configuration changes.
Upgrading modules...
- tenant in ../../modules/tenant
Downloading registry.terraform.io/Azure/avm-res-search-searchservice/azurerm 0.2.0 for tenant.ai_search...
- tenant.ai_search in /home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-ai-hub-admin/modules/tenant.ai_search
Downloading registry.terraform.io/Azure/avm-res-cognitiveservices-account/azurerm 0.7.1 for tenant.document_intelligence...
- tenant.document_intelligence in /home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-ai-hub-admin/modules/tenant.document_intelligence
Downloading registry.terraform.io/Azure/avm-res-keyvault-vault/azurerm 0.10.2 for tenant.key_vault...
- tenant.key_vault in /home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-ai-hub-admin/modules/tenant.key_vault
- tenant.key_vault.keys in /home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-ai-hub-admin/modules/tenant.key_vault/modules/key
- tenant.key_vault.secrets in /home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-ai-hub-admin/modules/tenant.key_vault/modules/secret
Downloading registry.terraform.io/Azure/avm-res-cognitiveservices-account/azurerm 0.7.1 for tenant.speech_services...
- tenant.speech_services in /home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-ai-hub-admin/modules/tenant.speech_services
Initializing provider plugins...
- terraform.io/builtin/terraform is built in to Terraform
- Finding hashicorp/azurerm versions matching ">= 3.117.0, ~> 4.0, >= 4.17.0, >= 4.38.0, < 5.0.0"...
- Finding azure/modtm versions matching "~> 0.3"...
- Finding hashicorp/random versions matching ">= 3.5.0, ~> 3.5, >= 3.7.0, < 4.0.0"...
- Finding hashicorp/null versions matching ">= 3.2.0"...
- Finding hashicorp/time versions matching "~> 0.9"...
- Finding azure/azapi versions matching "~> 2.0, ~> 2.4, >= 2.5.0"...
- Installing azure/azapi v2.8.0...
- Installed azure/azapi v2.8.0 (signed by a HashiCorp partner, key ID 6F0B91BDE98478CF)
- Installing hashicorp/azurerm v4.63.0...
- Installed hashicorp/azurerm v4.63.0 (signed by HashiCorp)
- Installing azure/modtm v0.3.5...
- Installed azure/modtm v0.3.5 (signed by a HashiCorp partner, key ID 6F0B91BDE98478CF)
- Installing hashicorp/random v3.8.1...
- Installed hashicorp/random v3.8.1 (signed by HashiCorp)
- Installing hashicorp/null v3.2.4...
- Installed hashicorp/null v3.2.4 (signed by HashiCorp)
- Installing hashicorp/time v0.13.1...
- Installed hashicorp/time v0.13.1 (signed by HashiCorp)
Partner and community providers are signed by their developers.
If you'd like to know more about provider signing, you can read about it here:
https://developer.hashicorp.com/terraform/cli/plugins/signing
Terraform has created a lock file .terraform.lock.hcl to record the provider
selections it made above. Include this file in your version control repository
so that Terraform can guarantee to make the same selections by default when
you run "terraform init" in the future.

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
2026-03-09T18:50:48Z [SUCCESS] terraform init (tenant:ai-hub-admin) completed successfully
2026-03-09T18:50:48Z [INFO] Starting terraform plan (tenant:ai-hub-admin) (attempt 1/5)
Acquiring state lock. This may take a few moments...
2026-03-09T18:50:52.699Z [ERROR] AttachSchemaTransformer: No provider config schema available for provider["terraform.io/builtin/terraform"]
2026-03-09T18:50:54.319Z [ERROR] AttachSchemaTransformer: No provider config schema available for provider["terraform.io/builtin/terraform"]
data.terraform_remote_state.shared: Reading...
module.tenant["ai-hub-admin"].random_string.suffix: Refreshing state... [id=418z]
data.terraform_remote_state.shared: Read complete after 1s
module.tenant["ai-hub-admin"].data.azurerm_client_config.current: Reading...
module.tenant["ai-hub-admin"].azurerm_resource_group.tenant: Refreshing state... [id=/subscriptions/****/resourceGroups/ai-hub-admin-rg]
module.tenant["ai-hub-admin"].data.azurerm_client_config.current: Read complete after 0s [id=Y2xpZW50Q29uZmlncy9jbGllbnRJZD1kZmZiM2UzZC1kMjU5LTQ2NmUtODUwYS1kOTEyYTI1NGViNjM7b2JqZWN0SWQ9YjE0NTQ5NTItNTg4ZS00MzUzLTk3ZTAtMTVhY2MwZGViYjcyO3N1YnNjcmlwdGlvbklkPTM0YzVlNmQ4LTA2NjUtNDg3Ny04MGE1LThjMGY1N2IxNGIzMzt0ZW5hbnRJZD02ZmRiNTIwMC0zZDBkLTRhOGEtYjAzNi1kMzY4NWUzNTlhZGM=]
module.tenant["ai-hub-admin"].azurerm_log_analytics_workspace.tenant[0]: Refreshing state... [id=/subscriptions/****/resourceGroups/ai-hub-admin-rg/providers/Microsoft.OperationalInsights/workspaces/aihubadmin-law-418z]
module.tenant["ai-hub-admin"].module.document_intelligence[0].random_string.default_custom_subdomain_name_suffix[0]: Refreshing state... [id=kczgc]
module.tenant["ai-hub-admin"].azurerm_storage_account.this[0]: Refreshing state... [id=/subscriptions/****/resourceGroups/ai-hub-admin-rg/providers/Microsoft.Storage/storageAccounts/aihubadminst418z]
module.tenant["ai-hub-admin"].module.document_intelligence[0].azurerm_cognitive_account.this[0]: Refreshing state... [id=/subscriptions/****/resourceGroups/ai-hub-admin-rg/providers/Microsoft.CognitiveServices/accounts/ai-hub-admin-docint-418z]
module.tenant["ai-hub-admin"].module.document_intelligence[0].azurerm_private_endpoint.this_unmanaged_dns_zone_groups["primary"]: Refreshing state... [id=/subscriptions/****/resourceGroups/ai-hub-admin-rg/providers/Microsoft.Network/privateEndpoints/pep-ai-hub-admin-docint-418z]
module.tenant["ai-hub-admin"].azurerm_application_insights.tenant[0]: Refreshing state... [id=/subscriptions/****/resourceGroups/ai-hub-admin-rg/providers/Microsoft.Insights/components/aihubadmin-appi-418z]
module.tenant["ai-hub-admin"].azurerm_monitor_diagnostic_setting.document_intelligence[0]: Refreshing state... [id=/subscriptions/****/resourceGroups/ai-hub-admin-rg/providers/Microsoft.CognitiveServices/accounts/ai-hub-admin-docint-418z|ai-hub-admin-docint-diag]
module.tenant["ai-hub-admin"].null_resource.wait_for_dns_document_intelligence[0]: Refreshing state... [id=2996673960704066107]
module.tenant["ai-hub-admin"].azurerm_storage_container.default[0]: Refreshing state... [id=/subscriptions/****/resourceGroups/ai-hub-admin-rg/providers/Microsoft.Storage/storageAccounts/aihubadminst418z/blobServices/default/containers/default]
module.tenant["ai-hub-admin"].azurerm_monitor_diagnostic_setting.storage[0]: Refreshing state... [id=/subscriptions/****/resourceGroups/ai-hub-admin-rg/providers/Microsoft.Storage/storageAccounts/aihubadminst418z|ai-hub-admin-storage-diag]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration
and found no differences, so no changes are needed.

Warning: Value for undeclared variable

The root module does not declare a variable named "defender_enabled" but a
value was found in file
"/home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/params/test/shared.tfvars".
If you meant to use this value, add a "variable" block to the configuration.

To silence these warnings, use TF_VAR_... environment variables to provide
certain "global" settings to all configurations in your organization. To
reduce the verbosity of these warnings, use the -compact-warnings option.

Warning: Value for undeclared variable

The root module does not declare a variable named "defender_resource_types"
but a value was found in file
"/home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/params/test/shared.tfvars".
If you meant to use this value, add a "variable" block to the configuration.

To silence these warnings, use TF_VAR_... environment variables to provide
certain "global" settings to all configurations in your organization. To
reduce the ve
(truncated, see workflow logs for complete plan)
```

</details>

---
_Updated by CI — plan against `test` environment (run [#254](https://github.com/bcgov/ai-hub-tracking/actions/runs/22869372864)) at 2026-03-09 18:52:18 UTC._
<!-- /ai-hub-infra-changes -->