### PR TITLE
fix: the missing values should not report error, the code handles if …

### DIFF
--- a/.github/hooks/hooks.json
+++ b/.github/hooks/hooks.json
@@ -5,7 +5,7 @@
       {
         "type": "command",
         "bash": "bash .github/hooks/scripts/guard-destructive.sh",
-        "powershell": ".github/hooks/scripts/guard-destructive.ps1",
+        "powershell": "powershell -ExecutionPolicy Bypass -File .github/hooks/scripts/guard-destructive.ps1",
         "cwd": ".",
         "timeoutSec": 10,
         "comment": "Block dangerous bash commands (force-push, hard-reset, rm -rf on infra dirs)"
@@ -15,7 +15,7 @@
       {
         "type": "command",
         "bash": "bash .github/hooks/scripts/portal-lint-check.sh",
-        "powershell": ".github/hooks/scripts/portal-lint-check.ps1",
+        "powershell": "powershell -ExecutionPolicy Bypass -File .github/hooks/scripts/portal-lint-check.ps1",
         "cwd": ".",
         "timeoutSec": 240,
         "comment": "Mirror .pre-commit-config.yaml portal hooks: lint + format:check for backend and frontend after every TypeScript file edit or create"

--- a/.github/scripts/collect-hub-outputs.sh
+++ b/.github/scripts/collect-hub-outputs.sh
@@ -63,12 +63,22 @@ az storage blob download \
   --name "$apim_blob_name" \
   --auth-mode login --file /tmp/apim.tfstate --output none
 
-hub_kv_id="$(jq -er '.outputs.hub_key_vault_id.value' /tmp/shared.tfstate)"
-hub_kv_url="$(jq -er '.outputs.hub_key_vault_uri.value' /tmp/shared.tfstate)"
-apim_url="$(jq -er '.outputs.apim_gateway_url.value' /tmp/apim.tfstate)"
+hub_kv_id="$(jq -r '.outputs.hub_key_vault_id.value // empty' /tmp/shared.tfstate)"
+hub_kv_url="$(jq -r '.outputs.hub_key_vault_uri.value // empty' /tmp/shared.tfstate)"
+apim_url="$(jq -r '.outputs.apim_gateway_url.value // empty' /tmp/apim.tfstate)"
+
+if [[ -z "$hub_kv_id" ]]; then
+  echo "::warning::hub_key_vault_id could not be found in shared tfstate for environment '$HUB_ENV'" >&2
+fi
+if [[ -z "$hub_kv_url" ]]; then
+  echo "::warning::hub_key_vault_uri could not be found in shared tfstate for environment '$HUB_ENV'" >&2
+fi
+if [[ -z "$apim_url" ]]; then
+  echo "::warning::apim_gateway_url could not be found in apim tfstate for environment '$HUB_ENV'" >&2
+fi
 
 if [[ -z "$hub_kv_id" || -z "$hub_kv_url" || -z "$apim_url" ]]; then
-  echo "Required Terraform outputs are missing or empty for environment '$HUB_ENV'." >&2
+  echo "Required Terraform outputs are missing or empty for environment '$HUB_ENV', skipping output." >&2
   exit 0
 fi
 

--- a/initial-setup/initial-azure-setup.sh
+++ b/initial-setup/initial-azure-setup.sh
@@ -1037,29 +1037,76 @@ create_terraform_storage() {
 }
 
 # ================================================================================
-# Note about storage-specific permissions for Terraform state access
-# Storage permissions are typically handled through the main security group membership
+# Assign Storage Blob Data Reader to the managed identity on the Terraform state storage account.
+#
+# This role is required so the OIDC service principal can read tfstate blobs with
+# --auth-mode login (used by collect-hub-outputs.sh and terraform init).
+# Idempotent: does nothing if the assignment already exists.
 # ================================================================================
 assign_storage_roles() {
     if [[ "$CREATE_STORAGE" != "true" ]]; then
         return 0
     fi
-    
-    log_info "Storage access permissions..."
-    log_info "Storage permissions are managed through security group membership"
-    log_info "Ensure the security group has appropriate storage permissions:"
-    log_info "  - Storage Blob Data Contributor"
-    log_info "  - Storage Account Contributor"
-    
-    # Get storage account resource ID for reference
-    if [[ "$DRY_RUN" == "false" ]]; then
-        STORAGE_ACCOUNT_ID=$(az storage account show --name "$STORAGE_ACCOUNT" --resource-group "$RESOURCE_GROUP" --query "id" --output tsv)
-        log_info "Storage Account ID: $STORAGE_ACCOUNT_ID"
-    else
-        log_info "[DRY-RUN] Would note storage account permissions requirements"
+
+    local role_name="Storage Blob Data Reader"
+    log_info "Ensuring managed identity has '$role_name' role on storage account '$STORAGE_ACCOUNT'..."
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log_info "[DRY-RUN] Would ensure role '$role_name' is assigned to principal '$PRINCIPAL_ID' on storage account '$STORAGE_ACCOUNT'"
+        return 0
     fi
-    
-    log_success "Storage permissions documentation completed"
+
+    local storage_account_id
+    storage_account_id=$(az storage account show \
+        --name "$STORAGE_ACCOUNT" \
+        --resource-group "$RESOURCE_GROUP" \
+        --query "id" \
+        --output tsv)
+
+    # Check if role assignment already exists (idempotent)
+    local existing_assignment_id=""
+    set +e
+    existing_assignment_id=$(az role assignment list \
+        --assignee-object-id "$PRINCIPAL_ID" \
+        --scope "$storage_account_id" \
+        --role "$role_name" \
+        --query "[0].id" \
+        --output tsv 2>/dev/null)
+    local list_rc=$?
+    set -e
+
+    if [[ $list_rc -ne 0 ]]; then
+        log_warning "Unable to query existing role assignments. Skipping storage role assignment."
+        log_warning "If collect-hub-outputs fails with a permissions error, manually assign '$role_name' to '$IDENTITY_NAME' on storage account '$STORAGE_ACCOUNT'."
+        return 0
+    fi
+
+    if [[ -n "$existing_assignment_id" ]]; then
+        log_success "Role '$role_name' is already assigned on storage account '$STORAGE_ACCOUNT'"
+        return 0
+    fi
+
+    log_info "Creating role assignment '$role_name' for principal '$PRINCIPAL_ID' on storage account '$STORAGE_ACCOUNT'..."
+    local create_output=""
+    set +e
+    create_output=$(az role assignment create \
+        --assignee-object-id "$PRINCIPAL_ID" \
+        --assignee-principal-type ServicePrincipal \
+        --role "$role_name" \
+        --scope "$storage_account_id" 2>&1)
+    local create_rc=$?
+    set -e
+
+    if [[ $create_rc -eq 0 ]] || echo "$create_output" | grep -qi "RoleAssignmentExists"; then
+        log_success "Assigned '$role_name' to managed identity '$IDENTITY_NAME' on storage account '$STORAGE_ACCOUNT'"
+        return 0
+    fi
+
+    log_warning "Failed to create role assignment '$role_name'."
+    log_warning "This typically requires Owner or User Access Administrator on the scope."
+    log_warning "Azure CLI output: $create_output"
+    log_warning "Manual action: assign '$role_name' to '$IDENTITY_NAME' (principal: $PRINCIPAL_ID) on storage account '$STORAGE_ACCOUNT'."
+    return 0
 }
 
 # =============================================================================


### PR DESCRIPTION
…url or id is not provided.

<!-- ai-hub-infra-changes -->
## AI Hub Infra Changes

**Summary:** 1 to add, 14 to change, 0 to destroy (across 2 stack(s))

<details><summary>Show plan details</summary>

```hcl
Terraform will perform the following actions:

  # module.foundry_project["ai-hub-admin"].azapi_resource.rai_policy["gpt-5.1-chat"] will be updated in-place
  ~ resource "azapi_resource" "rai_policy" {
      ~ body                      = {
          ~ properties = {
              ~ contentFilters = [
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Violence" -> "violence"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Violence" -> "violence"
                        # (4 unchanged attributes hidden)
                    },
                ]
                # (2 unchanged attributes hidden)
            }
        }
        id                        = "/subscriptions/****/resourceGroups/ai-services-hub-test/providers/Microsoft.CognitiveServices/accounts/ai-services-hub-test-foundry/raiPolicies/ai-hub-admin-gpt-5-1-chat-filter"
        name                      = "ai-hub-admin-gpt-5-1-chat-filter"
      ~ output                    = {
          - id         = "/subscriptions/****/resourceGroups/ai-services-hub-test/providers/Microsoft.CognitiveServices/accounts/ai-services-hub-test-foundry/raiPolicies/ai-hub-admin-gpt-5-1-chat-filter"
          - properties = {
              - contentFilters = [
                  - {},
                  - {},
                  - {},
                  - {},
                  - {},
                  - {},
                  - {},
                  - {},
                ]
              - type           = "UserManaged"
            }
          - type       = "Microsoft.CognitiveServices/accounts/raiPolicies"
        } -> (known after apply)
        # (7 unchanged attributes hidden)
    }

  # module.foundry_project["gcpe-media-monitoring"].azapi_resource.rai_policy["gpt-4.1"] will be updated in-place
  ~ resource "azapi_resource" "rai_policy" {
      ~ body                      = {
          ~ properties = {
              ~ contentFilters = [
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Violence" -> "violence"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Violence" -> "violence"
                        # (4 unchanged attributes hidden)
                    },
                ]
                # (2 unchanged attributes hidden)
            }
        }
        id                        = "/subscriptions/****/resourceGroups/ai-services-hub-test/providers/Microsoft.CognitiveServices/accounts/ai-services-hub-test-foundry/raiPolicies/gcpe-media-monitoring-gpt-4-1-filter"
        name                      = "gcpe-media-monitoring-gpt-4-1-filter"
      ~ output                    = {
          - id         = "/subscriptions/****/resourceGroups/ai-services-hub-test/providers/Microsoft.CognitiveServices/accounts/ai-services-hub-test-foundry/raiPolicies/gcpe-media-monitoring-gpt-4-1-filter"
          - properties = {
              - contentFilters = [
                  - {},
                  - {},
                  - {},
                  - {},
                  - {},
                  - {},
                  - {},
                  - {},
                ]
              - type           = "UserManaged"
            }
          - type       = "Microsoft.CognitiveServices/accounts/raiPolicies"
        } -> (known after apply)
        # (7 unchanged attributes hidden)
    }

  # module.foundry_project["gcpe-media-monitoring"].azapi_resource.rai_policy["gpt-4.1-mini"] will be updated in-place
  ~ resource "azapi_resource" "rai_policy" {
      ~ body                      = {
          ~ properties = {
              ~ contentFilters = [
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Violence" -> "violence"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Violence" -> "violence"
                        # (4 unchanged attributes hidden)
                    },
                ]
                # (2 unchanged attributes hidden)
            }
        }
        id                        = "/subscriptions/****/resourceGroups/ai-services-hub-test/providers/Microsoft.CognitiveServices/accounts/ai-services-hub-test-foundry/raiPolicies/gcpe-media-monitoring-gpt-4-1-mini-filter"
        name                      = "gcpe-media-monitoring-gpt-4-1-mini-filter"
      ~ output                    = {
          - id         = "/subscriptions/****/resourceGroups/ai-services-hub-test/providers/Microsoft.CognitiveServices/accounts/ai-services-hub-test-foundry/raiPolicies/gcpe-media-monitoring-gpt-4-1-mini-filter"
          - properties = {
              - contentFilters = [
                  - {},
                  - {},
                  - {},
                  - {},
                  - {},
                  - {},
                  - {},
                  - {},
                ]
              - type           = "UserManaged"
            }
          - type       = "Microsoft.CognitiveServices/accounts/raiPolicies"
        } -> (known after apply)
        # (7 unchanged attributes hidden)
    }

  # module.foundry_project["gcpe-media-monitoring"].azapi_resource.rai_policy["gpt-4.1-nano"] will be updated in-place
  ~ resource "azapi_resource" "rai_policy" {
      ~ body                      = {
          ~ properties = {
              ~ contentFilters = [
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
```

</details>

---
_Updated by CI — plan against `test` environment (run [#284](https://github.com/bcgov/ai-hub-tracking/actions/runs/23078392833)) at 2026-03-14 02:35:39 UTC._
<!-- /ai-hub-infra-changes -->