### PR TITLE
fix: vars and memory allocation

### DIFF
--- a/infra-ai-hub/modules/pii-redaction-service/variables.tf
+++ b/infra-ai-hub/modules/pii-redaction-service/variables.tf
@@ -71,7 +71,6 @@ variable "language_service_id" {
 variable "language_api_version" {
   description = "Language API version string (PII_LANGUAGE_API_VERSION)."
   type        = string
-  default     = "2025-11-15-preview"
 }
 
 # ---------------------------------------------------------------------------

--- a/infra-ai-hub/stacks/pii-redaction/main.tf
+++ b/infra-ai-hub/stacks/pii-redaction/main.tf
@@ -26,9 +26,10 @@ module "pii_redaction_service" {
   container_registry_url = lookup(local.pii_redaction_config, "container_registry_url", "ghcr.io")
   container_image_name   = lookup(local.pii_redaction_config, "container_image_name", "bcgov/ai-hub-tracking/pii-redaction-service")
   container_image_tag    = var.container_image_tag_svc_pii_redaction != "" ? var.container_image_tag_svc_pii_redaction : lookup(local.pii_redaction_config, "container_image_tag", "latest")
-
+  language_api_version   = var.language_api_version
+  # https://learn.microsoft.com/en-gb/azure/container-apps/containers#allocations
   cpu          = lookup(local.pii_redaction_config, "cpu", 0.25)
-  memory       = lookup(local.pii_redaction_config, "memory", "512Mi")
+  memory       = lookup(local.pii_redaction_config, "memory", "0.5Gi")
   min_replicas = lookup(local.pii_redaction_config, "min_replicas", 1)
   max_replicas = lookup(local.pii_redaction_config, "max_replicas", 5)
   log_level    = lookup(local.pii_redaction_config, "log_level", "INFO")

--- a/infra-ai-hub/stacks/pii-redaction/variables.tf
+++ b/infra-ai-hub/stacks/pii-redaction/variables.tf
@@ -69,3 +69,8 @@ variable "container_image_tag_svc_pii_redaction" {
   type        = string
   default     = ""
 }
+variable "language_api_version" {
+  description = "Override Language API version string (empty = use config default, typically stable GA version)"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION


<!-- ai-hub-infra-changes -->
## AI Hub Infra Changes

**Summary:** 1 to add, 18 to change, 0 to destroy (across 4 stack(s))

<details><summary>Show plan details</summary>

```hcl
Terraform will perform the following actions:

  # module.foundry_project["ai-hub-admin"].azapi_resource.rai_policy["gpt-5.1-chat"] will be updated in-place
  ~ resource "azapi_resource" "rai_policy" {
      ~ body                      = {
          ~ properties = {
              ~ contentFilters = [
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Violence" -> "violence"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Violence" -> "violence"
                        # (4 unchanged attributes hidden)
                    },
                ]
                # (2 unchanged attributes hidden)
            }
        }
        id                        = "/subscriptions/****/resourceGroups/ai-services-hub-test/providers/Microsoft.CognitiveServices/accounts/ai-services-hub-test-foundry/raiPolicies/ai-hub-admin-gpt-5-1-chat-filter"
        name                      = "ai-hub-admin-gpt-5-1-chat-filter"
      ~ output                    = {
          - id         = "/subscriptions/****/resourceGroups/ai-services-hub-test/providers/Microsoft.CognitiveServices/accounts/ai-services-hub-test-foundry/raiPolicies/ai-hub-admin-gpt-5-1-chat-filter"
          - properties = {
              - contentFilters = [
                  - {},
                  - {},
                  - {},
                  - {},
                  - {},
                  - {},
                  - {},
                  - {},
                ]
              - type           = "UserManaged"
            }
          - type       = "Microsoft.CognitiveServices/accounts/raiPolicies"
        } -> (known after apply)
        # (7 unchanged attributes hidden)
    }

  # module.foundry_project["gcpe-media-monitoring"].azapi_resource.rai_policy["gpt-4.1"] will be updated in-place
  ~ resource "azapi_resource" "rai_policy" {
      ~ body                      = {
          ~ properties = {
              ~ contentFilters = [
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Violence" -> "violence"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Violence" -> "violence"
                        # (4 unchanged attributes hidden)
                    },
                ]
                # (2 unchanged attributes hidden)
            }
        }
        id                        = "/subscriptions/****/resourceGroups/ai-services-hub-test/providers/Microsoft.CognitiveServices/accounts/ai-services-hub-test-foundry/raiPolicies/gcpe-media-monitoring-gpt-4-1-filter"
        name                      = "gcpe-media-monitoring-gpt-4-1-filter"
      ~ output                    = {
          - id         = "/subscriptions/****/resourceGroups/ai-services-hub-test/providers/Microsoft.CognitiveServices/accounts/ai-services-hub-test-foundry/raiPolicies/gcpe-media-monitoring-gpt-4-1-filter"
          - properties = {
              - contentFilters = [
                  - {},
                  - {},
                  - {},
                  - {},
                  - {},
                  - {},
                  - {},
                  - {},
                ]
              - type           = "UserManaged"
            }
          - type       = "Microsoft.CognitiveServices/accounts/raiPolicies"
        } -> (known after apply)
        # (7 unchanged attributes hidden)
    }

  # module.foundry_project["gcpe-media-monitoring"].azapi_resource.rai_policy["gpt-4.1-mini"] will be updated in-place
  ~ resource "azapi_resource" "rai_policy" {
      ~ body                      = {
          ~ properties = {
              ~ contentFilters = [
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Violence" -> "violence"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Violence" -> "violence"
                        # (4 unchanged attributes hidden)
                    },
                ]
                # (2 unchanged attributes hidden)
            }
        }
        id                        = "/subscriptions/****/resourceGroups/ai-services-hub-test/providers/Microsoft.CognitiveServices/accounts/ai-services-hub-test-foundry/raiPolicies/gcpe-media-monitoring-gpt-4-1-mini-filter"
        name                      = "gcpe-media-monitoring-gpt-4-1-mini-filter"
      ~ output                    = {
          - id         = "/subscriptions/****/resourceGroups/ai-services-hub-test/providers/Microsoft.CognitiveServices/accounts/ai-services-hub-test-foundry/raiPolicies/gcpe-media-monitoring-gpt-4-1-mini-filter"
          - properties = {
              - contentFilters = [
                  - {},
                  - {},
                  - {},
                  - {},
                  - {},
                  - {},
                  - {},
                  - {},
                ]
              - type           = "UserManaged"
            }
          - type       = "Microsoft.CognitiveServices/accounts/raiPolicies"
        } -> (known after apply)
        # (7 unchanged attributes hidden)
    }

  # module.foundry_project["gcpe-media-monitoring"].azapi_resource.rai_policy["gpt-4.1-nano"] will be updated in-place
  ~ resource "azapi_resource" "rai_policy" {
      ~ body                      = {
          ~ properties = {
              ~ contentFilters = [
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
```

</details>

---
_Updated by CI — plan against `test` environment (run [#299](https://github.com/bcgov/ai-hub-tracking/actions/runs/23120086293)) at 2026-03-15 21:54:13 UTC._
<!-- /ai-hub-infra-changes -->