### PR TITLE
chore: Revert "fix: group creation"

### DIFF
--- a/infra-ai-hub/modules/tenant-user-management/README.md
+++ b/infra-ai-hub/modules/tenant-user-management/README.md
@@ -7,8 +7,8 @@ tenant resource group scope. Supports two assignment modes:
 
 | Mode | Flag | Description |
 |---|---|---|
-| **Group** | `create_groups = true` (default) | Creates Entra ID security groups, adds seed members, and assigns roles to groups. Requires `Group.ReadWrite.All` Graph API permission. |
-| **Direct User** | `create_groups = false` | Assigns custom RBAC roles directly to individual users. No Entra ID group permissions needed. |
+| **Direct User** | `create_groups = false` (default) | Assigns custom RBAC roles directly to individual users. No Entra ID group permissions needed. |
+| **Group** | `create_groups = true` | Creates Entra ID security groups, adds seed members, and assigns roles to groups. Requires `Group.ReadWrite.All` Graph API permission. |
 
 ## Resources Created
 
@@ -25,10 +25,8 @@ tenant resource group scope. Supports two assignment modes:
 
 - **Environment prefix** — Group and role names include `app_env` to prevent
   collisions in the shared Entra tenant across dev/test/prod.
-- **Group mode default** — `create_groups` defaults to `true` so tenants
-  get Entra security groups out of the box. The `tenant-user-mgmt` stack
-  automatically falls back to direct-user mode when `graph_client_id` is not
-  set, so pipelines without `Group.ReadWrite.All` degrade gracefully.
+- **Direct user mode default** — Does not require Entra ID group creation
+  permissions, making it safe for all environments including local development.
 - **Switchable** — Moving from `create_groups = false` to `true` will replace
   individual user assignments with group-based ones (Terraform handles lifecycle).
 - **Add-only membership** (group mode) — Uses individual `azuread_group_member`
@@ -55,7 +53,7 @@ module "tenant_user_management" {
 
 ## Tenant Configuration
 
-Group mode (default — requires `Group.ReadWrite.All` via `graph_client_id`):
+Direct user mode (default — no group permissions needed):
 
 ```hcl
 user_management = {
@@ -67,11 +65,11 @@ user_management = {
 }
 ```
 
-Direct user mode (explicit opt-out, or automatic when `graph_client_id` is absent):
+Group mode (requires `Group.ReadWrite.All` Graph API permission):
 
 ```hcl
 user_management = {
-  create_groups = false
+  create_groups = true
   seed_members = {
     admin = ["alice@gov.bc.ca", "bob@gov.bc.ca"]
     write = ["charlie@gov.bc.ca"]
@@ -103,7 +101,7 @@ user_management = {
 | Field | Description | Default |
 |---|---|---|
 | `enabled` | Enable/disable user management | `true` |
-| `create_groups` | Create Entra groups (vs direct user assignment) | `true` |
+| `create_groups` | Create Entra groups (vs direct user assignment) | `false` |
 | `group_prefix` | Prefix for group/role names | `"ai-hub"` |
 | `mail_enabled` | Enable mail on security groups | `false` |
 | `existing_group_ids` | Reuse existing Entra group IDs | `{}` |

--- a/infra-ai-hub/modules/tenant-user-management/variables.tf
+++ b/infra-ai-hub/modules/tenant-user-management/variables.tf
@@ -42,7 +42,7 @@ variable "user_management" {
     # When true, creates Entra security groups and assigns roles to groups.
     # When false, assigns custom RBAC roles directly to individual users.
     # Requires Group.ReadWrite.All Graph API permission when true.
-    create_groups = optional(bool, true)
+    create_groups = optional(bool, false)
     group_prefix  = optional(string, "CITZ-CSBC-AI-HUB")
     mail_enabled  = optional(bool, false)
     existing_group_ids = optional(object({

--- a/infra-ai-hub/params/test/tenants/ai-hub-admin/tenant.tfvars
+++ b/infra-ai-hub/params/test/tenants/ai-hub-admin/tenant.tfvars
@@ -342,13 +342,7 @@ tenant = {
   }
 
   # Tenant user management (applies across environments)
-  # No seed members for the admin tenant — empty lists keep the map(any) shape
-  # consistent with other tenants while avoiding empty Entra groups.
-  user_management = {
-    seed_members = {
-      admin = []
-    }
-  }
+  user_management = {}
 
   # APIM Policies Configuration
   # Consolidates all APIM policy settings for this tenant

--- a/infra-ai-hub/stacks/tenant-user-mgmt/locals.tf
+++ b/infra-ai-hub/stacks/tenant-user-mgmt/locals.tf
@@ -1,23 +1,6 @@
 locals {
-  # When the stack runs without a dedicated Graph client (graph_client_id = ""),
-  # the azuread provider falls back to the ARM service principal which typically
-  # lacks Group.ReadWrite.All. Force create_groups = false in that case so the
-  # pipeline degrades gracefully to direct-user assignment instead of failing.
-  # nonsensitive() is safe here: the boolean "do we have a Graph client?" is not
-  # itself a secret — only the client ID value is.
-  has_graph_permission = nonsensitive(var.graph_client_id != "")
-
   enabled_tenants = {
     for key, config in var.tenants :
-    key => merge(config, {
-      user_management = merge(
-        # Auto-disable when no seed members are configured to avoid empty Entra groups.
-        # Placed first so an explicit enabled = true in tfvars can override.
-        length(try(flatten(values(try(config.user_management.seed_members, {}))), [])) == 0 ? { enabled = false } : {},
-        try(config.user_management, {}),
-        local.has_graph_permission ? {} : { create_groups = false }
-      )
-    })
-    if config.enabled
+    key => config if config.enabled
   }
 }


### PR DESCRIPTION
Reverts bcgov/ai-hub-tracking#160

<!-- ai-hub-infra-changes -->
## AI Hub Infra Changes

**Summary:** 16 to add, 19 to change, 0 to destroy (across 5 stack(s))

<details><summary>Show plan details</summary>

```hcl
Terraform will perform the following actions:

  # module.foundry_project["ai-hub-admin"].azapi_resource.rai_policy["gpt-5.1-chat"] will be updated in-place
  ~ resource "azapi_resource" "rai_policy" {
      ~ body                      = {
          ~ properties = {
              ~ contentFilters = [
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Violence" -> "violence"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Violence" -> "violence"
                        # (4 unchanged attributes hidden)
                    },
                ]
                # (2 unchanged attributes hidden)
            }
        }
        id                        = "/subscriptions/****/resourceGroups/ai-services-hub-test/providers/Microsoft.CognitiveServices/accounts/ai-services-hub-test-foundry/raiPolicies/ai-hub-admin-gpt-5-1-chat-filter"
        name                      = "ai-hub-admin-gpt-5-1-chat-filter"
      ~ output                    = {
          - id         = "/subscriptions/****/resourceGroups/ai-services-hub-test/providers/Microsoft.CognitiveServices/accounts/ai-services-hub-test-foundry/raiPolicies/ai-hub-admin-gpt-5-1-chat-filter"
          - properties = {
              - contentFilters = [
                  - {},
                  - {},
                  - {},
                  - {},
                  - {},
                  - {},
                  - {},
                  - {},
                ]
              - type           = "UserManaged"
            }
          - type       = "Microsoft.CognitiveServices/accounts/raiPolicies"
        } -> (known after apply)
        # (7 unchanged attributes hidden)
    }

  # module.foundry_project["gcpe-media-monitoring"].azapi_resource.rai_policy["gpt-4.1"] will be updated in-place
  ~ resource "azapi_resource" "rai_policy" {
      ~ body                      = {
          ~ properties = {
              ~ contentFilters = [
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Violence" -> "violence"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Violence" -> "violence"
                        # (4 unchanged attributes hidden)
                    },
                ]
                # (2 unchanged attributes hidden)
            }
        }
        id                        = "/subscriptions/****/resourceGroups/ai-services-hub-test/providers/Microsoft.CognitiveServices/accounts/ai-services-hub-test-foundry/raiPolicies/gcpe-media-monitoring-gpt-4-1-filter"
        name                      = "gcpe-media-monitoring-gpt-4-1-filter"
      ~ output                    = {
          - id         = "/subscriptions/****/resourceGroups/ai-services-hub-test/providers/Microsoft.CognitiveServices/accounts/ai-services-hub-test-foundry/raiPolicies/gcpe-media-monitoring-gpt-4-1-filter"
          - properties = {
              - contentFilters = [
                  - {},
                  - {},
                  - {},
                  - {},
                  - {},
                  - {},
                  - {},
                  - {},
                ]
              - type           = "UserManaged"
            }
          - type       = "Microsoft.CognitiveServices/accounts/raiPolicies"
        } -> (known after apply)
        # (7 unchanged attributes hidden)
    }

  # module.foundry_project["gcpe-media-monitoring"].azapi_resource.rai_policy["gpt-4.1-mini"] will be updated in-place
  ~ resource "azapi_resource" "rai_policy" {
      ~ body                      = {
          ~ properties = {
              ~ contentFilters = [
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Violence" -> "violence"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Violence" -> "violence"
                        # (4 unchanged attributes hidden)
                    },
                ]
                # (2 unchanged attributes hidden)
            }
        }
        id                        = "/subscriptions/****/resourceGroups/ai-services-hub-test/providers/Microsoft.CognitiveServices/accounts/ai-services-hub-test-foundry/raiPolicies/gcpe-media-monitoring-gpt-4-1-mini-filter"
        name                      = "gcpe-media-monitoring-gpt-4-1-mini-filter"
      ~ output                    = {
          - id         = "/subscriptions/****/resourceGroups/ai-services-hub-test/providers/Microsoft.CognitiveServices/accounts/ai-services-hub-test-foundry/raiPolicies/gcpe-media-monitoring-gpt-4-1-mini-filter"
          - properties = {
              - contentFilters = [
                  - {},
                  - {},
                  - {},
                  - {},
                  - {},
                  - {},
                  - {},
                  - {},
                ]
              - type           = "UserManaged"
            }
          - type       = "Microsoft.CognitiveServices/accounts/raiPolicies"
        } -> (known after apply)
        # (7 unchanged attributes hidden)
    }

  # module.foundry_project["gcpe-media-monitoring"].azapi_resource.rai_policy["gpt-4.1-nano"] will be updated in-place
  ~ resource "azapi_resource" "rai_policy" {
      ~ body                      = {
          ~ properties = {
              ~ contentFilters = [
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
```

</details>

---
_Updated by CI — plan against `test` environment (run [#307](https://github.com/bcgov/ai-hub-tracking/actions/runs/23671149528)) at 2026-03-27 23:08:57 UTC._
<!-- /ai-hub-infra-changes -->