### PR TITLE
feat: version upgrades of avm and foundry

### DIFF
--- a/infra-ai-hub/modules/ai-foundry-hub/main.tf
+++ b/infra-ai-hub/modules/ai-foundry-hub/main.tf
@@ -72,7 +72,7 @@ resource "azurerm_application_insights" "this" {
 # Can be deployed to a different region than the VNet for model availability
 # -----------------------------------------------------------------------------
 resource "azapi_resource" "ai_foundry" {
-  type      = "Microsoft.CognitiveServices/accounts@2025-04-01-preview"
+  type      = "Microsoft.CognitiveServices/accounts@2025-12-01"
   name      = var.name
   location  = local.ai_location # May differ from PE location for model availability
   parent_id = var.resource_group_id
@@ -189,7 +189,7 @@ resource "azurerm_monitor_diagnostic_setting" "ai_foundry" {
 resource "azapi_resource" "ai_agent" {
   count = var.ai_agent.enabled ? 1 : 0
 
-  type      = "Microsoft.CognitiveServices/accounts/projects@2025-04-01-preview"
+  type      = "Microsoft.CognitiveServices/accounts/projects@2025-12-01"
   name      = "${var.name}-agent"
   location  = var.location
   parent_id = azapi_resource.ai_foundry.id

--- a/infra-ai-hub/modules/foundry-project/main.tf
+++ b/infra-ai-hub/modules/foundry-project/main.tf
@@ -16,7 +16,7 @@
 # AI FOUNDRY PROJECT
 # =============================================================================
 resource "azapi_resource" "project" {
-  type      = "Microsoft.CognitiveServices/accounts/projects@2025-10-01-preview"
+  type      = "Microsoft.CognitiveServices/accounts/projects@2025-12-01"
   name      = "${local.name_prefix}-project"
   location  = var.ai_location # Must match parent hub location
   parent_id = var.ai_foundry_hub_id
@@ -118,7 +118,7 @@ resource "azurerm_role_assignment" "project_to_docint" {
 resource "azapi_resource" "connection_storage" {
   count = var.storage_account.enabled && var.project_connections.storage ? 1 : 0
 
-  type      = "Microsoft.CognitiveServices/accounts/projects/connections@2025-04-01-preview"
+  type      = "Microsoft.CognitiveServices/accounts/projects/connections@2025-12-01"
   name      = "storage-${local.name_prefix}"
   parent_id = azapi_resource.project.id
 
@@ -146,7 +146,7 @@ resource "azapi_resource" "connection_storage" {
 resource "azapi_resource" "connection_ai_search" {
   count = var.ai_search.enabled && var.project_connections.ai_search ? 1 : 0
 
-  type      = "Microsoft.CognitiveServices/accounts/projects/connections@2025-04-01-preview"
+  type      = "Microsoft.CognitiveServices/accounts/projects/connections@2025-12-01"
   name      = "aisearch-${local.name_prefix}"
   parent_id = azapi_resource.project.id
 
@@ -175,7 +175,7 @@ resource "azapi_resource" "connection_ai_search" {
 resource "azapi_resource" "connection_cosmos" {
   count = var.cosmos_db.enabled && var.project_connections.cosmos_db ? 1 : 0
 
-  type      = "Microsoft.CognitiveServices/accounts/projects/connections@2025-04-01-preview"
+  type      = "Microsoft.CognitiveServices/accounts/projects/connections@2025-12-01"
   name      = "cosmosdb-${local.name_prefix}"
   parent_id = azapi_resource.project.id
 
@@ -225,7 +225,7 @@ resource "azapi_resource" "rai_policy" {
   for_each = { for k, v in var.ai_model_deployments : k => v if length(v.content_filter.filters) > 0 }
 
   name      = replace("${var.tenant_name}-${each.value.name}-filter", ".", "-")
-  type      = "Microsoft.CognitiveServices/accounts/raiPolicies@2025-04-01-preview"
+  type      = "Microsoft.CognitiveServices/accounts/raiPolicies@2025-12-01"
   parent_id = var.ai_foundry_hub_id
 
   body = {
@@ -251,7 +251,7 @@ resource "azapi_resource" "ai_model_deployment" {
   # Prefix with tenant name to ensure uniqueness on shared Hub
   name      = "${var.tenant_name}-${each.value.name}"
   parent_id = var.ai_foundry_hub_id
-  type      = "Microsoft.CognitiveServices/accounts/deployments@2025-10-01-preview"
+  type      = "Microsoft.CognitiveServices/accounts/deployments@2025-12-01"
 
   body = {
     properties = {
@@ -282,7 +282,7 @@ resource "azapi_resource" "ai_model_deployment" {
 resource "azapi_resource" "connection_docint" {
   count = var.document_intelligence.enabled && var.project_connections.document_intelligence ? 1 : 0
 
-  type      = "Microsoft.CognitiveServices/accounts/projects/connections@2025-04-01-preview"
+  type      = "Microsoft.CognitiveServices/accounts/projects/connections@2025-12-01"
   name      = "docint-${local.name_prefix}"
   parent_id = azapi_resource.project.id
 

--- a/initial-setup/infra/modules/github-runners-aca/main.tf
+++ b/initial-setup/infra/modules/github-runners-aca/main.tf
@@ -7,7 +7,7 @@
 module "github_runners" {
   count   = var.enabled ? 1 : 0
   source  = "Azure/avm-ptn-cicd-agents-and-runners/azurerm"
-  version = "0.5.1"
+  version = "0.5.2"
 
   # Required inputs
   postfix                             = var.postfix

--- a/tenant-onboarding-portal/infra/main.tf
+++ b/tenant-onboarding-portal/infra/main.tf
@@ -65,7 +65,7 @@ resource "random_string" "storage_suffix" {
 
 module "portal_storage" {
   source  = "Azure/avm-res-storage-storageaccount/azurerm"
-  version = "0.6.7"
+  version = "0.6.8"
 
   name                = local.storage_account_name
   location            = var.location
@@ -106,7 +106,7 @@ module "portal_storage" {
 
 module "portal" {
   source  = "Azure/avm-res-web-site/azurerm"
-  version = "0.21.0"
+  version = "0.21.8"
 
   name                     = local.app_service_name
   location                 = var.location


### PR DESCRIPTION


<!-- ai-hub-infra-changes -->
## AI Hub Infra Changes

**Summary:** 2 to add, 17 to change, 0 to destroy (across 4 stack(s))

<details><summary>Show plan details</summary>

```hcl
Terraform will perform the following actions:

  # module.foundry_project["ai-hub-admin"].azapi_resource.rai_policy["gpt-5.1-chat"] will be updated in-place
  ~ resource "azapi_resource" "rai_policy" {
      ~ body                      = {
          ~ properties = {
              ~ contentFilters = [
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Violence" -> "violence"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Violence" -> "violence"
                        # (4 unchanged attributes hidden)
                    },
                ]
                # (2 unchanged attributes hidden)
            }
        }
        id                        = "/subscriptions/****/resourceGroups/ai-services-hub-test/providers/Microsoft.CognitiveServices/accounts/ai-services-hub-test-foundry/raiPolicies/ai-hub-admin-gpt-5-1-chat-filter"
        name                      = "ai-hub-admin-gpt-5-1-chat-filter"
      ~ output                    = {
          - id         = "/subscriptions/****/resourceGroups/ai-services-hub-test/providers/Microsoft.CognitiveServices/accounts/ai-services-hub-test-foundry/raiPolicies/ai-hub-admin-gpt-5-1-chat-filter"
          - properties = {
              - contentFilters = [
                  - {},
                  - {},
                  - {},
                  - {},
                  - {},
                  - {},
                  - {},
                  - {},
                ]
              - type           = "UserManaged"
            }
          - type       = "Microsoft.CognitiveServices/accounts/raiPolicies"
        } -> (known after apply)
      ~ type                      = "Microsoft.CognitiveServices/accounts/raiPolicies@2025-04-01-preview" -> "Microsoft.CognitiveServices/accounts/raiPolicies@2025-12-01"
        # (6 unchanged attributes hidden)
    }

  # module.foundry_project["gcpe-media-monitoring"].azapi_resource.rai_policy["gpt-4.1"] will be updated in-place
  ~ resource "azapi_resource" "rai_policy" {
      ~ body                      = {
          ~ properties = {
              ~ contentFilters = [
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Violence" -> "violence"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Violence" -> "violence"
                        # (4 unchanged attributes hidden)
                    },
                ]
                # (2 unchanged attributes hidden)
            }
        }
        id                        = "/subscriptions/****/resourceGroups/ai-services-hub-test/providers/Microsoft.CognitiveServices/accounts/ai-services-hub-test-foundry/raiPolicies/gcpe-media-monitoring-gpt-4-1-filter"
        name                      = "gcpe-media-monitoring-gpt-4-1-filter"
      ~ output                    = {
          - id         = "/subscriptions/****/resourceGroups/ai-services-hub-test/providers/Microsoft.CognitiveServices/accounts/ai-services-hub-test-foundry/raiPolicies/gcpe-media-monitoring-gpt-4-1-filter"
          - properties = {
              - contentFilters = [
                  - {},
                  - {},
                  - {},
                  - {},
                  - {},
                  - {},
                  - {},
                  - {},
                ]
              - type           = "UserManaged"
            }
          - type       = "Microsoft.CognitiveServices/accounts/raiPolicies"
        } -> (known after apply)
      ~ type                      = "Microsoft.CognitiveServices/accounts/raiPolicies@2025-04-01-preview" -> "Microsoft.CognitiveServices/accounts/raiPolicies@2025-12-01"
        # (6 unchanged attributes hidden)
    }

  # module.foundry_project["gcpe-media-monitoring"].azapi_resource.rai_policy["gpt-4.1-mini"] will be updated in-place
  ~ resource "azapi_resource" "rai_policy" {
      ~ body                      = {
          ~ properties = {
              ~ contentFilters = [
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Violence" -> "violence"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Violence" -> "violence"
                        # (4 unchanged attributes hidden)
                    },
                ]
                # (2 unchanged attributes hidden)
            }
        }
        id                        = "/subscriptions/****/resourceGroups/ai-services-hub-test/providers/Microsoft.CognitiveServices/accounts/ai-services-hub-test-foundry/raiPolicies/gcpe-media-monitoring-gpt-4-1-mini-filter"
        name                      = "gcpe-media-monitoring-gpt-4-1-mini-filter"
      ~ output                    = {
          - id         = "/subscriptions/****/resourceGroups/ai-services-hub-test/providers/Microsoft.CognitiveServices/accounts/ai-services-hub-test-foundry/raiPolicies/gcpe-media-monitoring-gpt-4-1-mini-filter"
          - properties = {
              - contentFilters = [
                  - {},
                  - {},
                  - {},
                  - {},
                  - {},
                  - {},
                  - {},
                  - {},
                ]
              - type           = "UserManaged"
            }
          - type       = "Microsoft.CognitiveServices/accounts/raiPolicies"
        } -> (known after apply)
      ~ type                      = "Microsoft.CognitiveServices/accounts/raiPolicies@2025-04-01-preview" -> "Microsoft.CognitiveServices/accounts/raiPolicies@2025-12-01"
        # (6 unchanged attributes hidden)
    }

  # module.foundry_project["gcpe-media-monitoring"].azapi_resource.rai_policy["gpt-4.1-nano"] will be updated in-place
  ~ resource "azapi_resource" "rai_policy" {
      ~ body                      = {
          ~ properties = {
              ~ contentFilters = [
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
```

</details>

---
_Updated by CI — plan against `test` environment (run [#309](https://github.com/bcgov/ai-hub-tracking/actions/runs/23692550396)) at 2026-03-28 19:29:30 UTC._
<!-- /ai-hub-infra-changes -->