### PR TITLE
feat: gpt-5.1 PTU deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,8 @@ local.settings.json
 terraform.tfvars
 .terraform/
 .terraform.lock.hcl
+*.tfstate
+*.tfstate.*
 .tenants-*.auto.tfvars
 crash.log
 _bkp

--- a/docs/_pages/apim-internal-endpoints.html
+++ b/docs/_pages/apim-internal-endpoints.html
@@ -126,10 +126,16 @@
     <p>Returns the tenant's deployed AI models (with quota information) and the set of enabled AI services. The response is <strong>fully static</strong> &mdash; data is baked in at Terraform deploy time via <code>templatefile()</code>, so no Key Vault or backend calls are made at runtime. Always available; there is no feature flag that disables this endpoint.</p>
     <p>Use this endpoint to:</p>
     <ul>
-        <li>Discover which models are available and their per-model token-per-minute quota.</li>
+        <li>Discover which models are available, the APIM raw-token cap for each model, and any provisioned-throughput metadata.</li>
         <li>Confirm which AI services (Document Intelligence, AI Search, Speech, etc.) are enabled for your tenant.</li>
         <li>Drive UI dropdowns or config auto-discovery without maintaining a separate config file.</li>
     </ul>
+</div>
+
+<div class="alert alert-info">
+    <div>
+        <strong>Provisioned throughput note:</strong> For provisioned models, Microsoft Foundry measures throughput as <em>input-equivalent</em> tokens per minute, and some models weight output tokens more heavily than input tokens. APIM's <code>llm-token-limit</code> policy only enforces raw prompt + completion tokens, so the platform publishes both values and uses a conservative APIM cap to avoid Foundry rejecting requests earlier than APIM. For WLRS <code>gpt-5.1</code>, the Foundry ceiling is <code>71,250</code> input-equivalent TPM, the output weighting is <code>8x</code>, and the conservative APIM raw-token cap is therefore <code>8,906</code> TPM.
+    </div>
 </div>
 
 <div class="card">
@@ -160,41 +166,53 @@
   "base_url": "https://aihub.gov.bc.ca/wlrs-water-form-assistant",
   "models": [
     {
-      "name": "gpt-4.1-mini",
-      "model_name": "gpt-4.1-mini",
-      "model_version": "2025-04-14",
-      "scale_type": "GlobalStandard",
-      "capacity_k_tpm": 1500,
-      "tokens_per_minute": 1500000,
+            "name": "gpt-5.1",
+            "model_name": "gpt-5.1",
+            "model_version": "2025-11-13",
+            "scale_type": "GlobalProvisionedManaged",
+            "capacity": 15,
+            "capacity_unit": "PTU",
+            "capacity_k_tpm": null,
+            "input_tpm_per_ptu": 4750,
+            "output_tokens_to_input_ratio": 8,
+            "apim_raw_tokens_per_minute": 8906,
+            "input_equivalent_tokens_per_minute": 71250,
+            "tokens_per_minute": 8906,
       "endpoints": {
         "azure_openai": {
           "endpoint": "https://aihub.gov.bc.ca/wlrs-water-form-assistant",
           "api_version": "2025-03-01-preview",
-          "url": "https://aihub.gov.bc.ca/wlrs-water-form-assistant/openai/deployments/gpt-4.1-mini/chat/completions?api-version=2025-03-01-preview"
+                    "url": "https://aihub.gov.bc.ca/wlrs-water-form-assistant/openai/deployments/gpt-5.1/chat/completions?api-version=2025-03-01-preview"
         },
         "openai_compatible": {
           "base_url": "https://aihub.gov.bc.ca/wlrs-water-form-assistant/openai/v1",
-          "model": "gpt-4.1-mini",
+                    "model": "gpt-5.1",
           "url": "https://aihub.gov.bc.ca/wlrs-water-form-assistant/openai/v1/chat/completions"
         }
       }
     },
     {
-      "name": "gpt-4.1",
-      "model_name": "gpt-4.1",
+            "name": "gpt-4.1-mini",
+            "model_name": "gpt-4.1-mini",
       "model_version": "2025-04-14",
       "scale_type": "GlobalStandard",
-      "capacity_k_tpm": 300,
-      "tokens_per_minute": 300000,
+            "capacity": 1500,
+            "capacity_unit": "k TPM",
+            "capacity_k_tpm": 1500,
+            "input_tpm_per_ptu": null,
+            "output_tokens_to_input_ratio": null,
+            "apim_raw_tokens_per_minute": 1500000,
+            "input_equivalent_tokens_per_minute": 1500000,
+            "tokens_per_minute": 1500000,
       "endpoints": {
         "azure_openai": {
           "endpoint": "https://aihub.gov.bc.ca/wlrs-water-form-assistant",
           "api_version": "2025-03-01-preview",
-          "url": "https://aihub.gov.bc.ca/wlrs-water-form-assistant/openai/deployments/gpt-4.1/chat/completions?api-version=2025-03-01-preview"
+                    "url": "https://aihub.gov.bc.ca/wlrs-water-form-assistant/openai/deployments/gpt-4.1-mini/chat/completions?api-version=2025-03-01-preview"
         },
         "openai_compatible": {
           "base_url": "https://aihub.gov.bc.ca/wlrs-water-form-assistant/openai/v1",
-          "model": "gpt-4.1",
+                    "model": "gpt-4.1-mini",
           "url": "https://aihub.gov.bc.ca/wlrs-water-form-assistant/openai/v1/chat/completions"
         }
       }
@@ -243,8 +261,14 @@
             <tr><td><code>models[].model_name</code></td><td>string</td><td>Underlying Azure OpenAI model name.</td></tr>
             <tr><td><code>models[].model_version</code></td><td>string</td><td>Model version date string.</td></tr>
             <tr><td><code>models[].scale_type</code></td><td>string</td><td>Deployment scale type (e.g., <code>GlobalStandard</code>).</td></tr>
-            <tr><td><code>models[].capacity_k_tpm</code></td><td>number</td><td>Allocated quota in thousands of tokens per minute (from <code>tenant.tfvars</code>).</td></tr>
-            <tr><td><code>models[].tokens_per_minute</code></td><td>number</td><td>Computed TPM limit applied by rate-limiting (<code>capacity_k_tpm &times; 1000</code>).</td></tr>
+            <tr><td><code>models[].capacity</code></td><td>number</td><td>Raw capacity value from <code>tenant.tfvars</code>. This is expressed in <code>capacity_unit</code>.</td></tr>
+            <tr><td><code>models[].capacity_unit</code></td><td>string</td><td>Capacity unit for the deployment. Current values are <code>k TPM</code> for quota-based deployments and <code>PTU</code> for provisioned deployments.</td></tr>
+            <tr><td><code>models[].capacity_k_tpm</code></td><td>number|null</td><td>Allocated quota in thousands of tokens per minute for quota-based deployments. <code>null</code> for provisioned deployments.</td></tr>
+            <tr><td><code>models[].input_tpm_per_ptu</code></td><td>number|null</td><td>Model-specific input TPM available per PTU for provisioned deployments. <code>null</code> for quota-based deployments.</td></tr>
+            <tr><td><code>models[].output_tokens_to_input_ratio</code></td><td>number|null</td><td>For provisioned deployments, how many input-equivalent tokens one output token consumes. <code>null</code> for quota-based deployments.</td></tr>
+            <tr><td><code>models[].apim_raw_tokens_per_minute</code></td><td>number</td><td>The raw prompt + completion token cap enforced by APIM's <code>llm-token-limit</code> policy. For provisioned deployments this is a conservative ceiling chosen so APIM does not allow traffic that Foundry would reject sooner.</td></tr>
+            <tr><td><code>models[].input_equivalent_tokens_per_minute</code></td><td>number</td><td>The Foundry throughput ceiling expressed in input-equivalent tokens per minute. For quota-based deployments this matches the APIM cap. For provisioned deployments this is typically higher than the APIM raw-token cap because output tokens are weighted more heavily.</td></tr>
+            <tr><td><code>models[].tokens_per_minute</code></td><td>number</td><td>Legacy alias for <code>apim_raw_tokens_per_minute</code>. Use the explicit fields above for new consumers.</td></tr>
             <tr><td><code>models[].endpoints.azure_openai.endpoint</code></td><td>string</td><td>Endpoint for the Azure OpenAI SDK (<code>AzureOpenAI(azure_endpoint=...)</code>).</td></tr>
             <tr><td><code>models[].endpoints.azure_openai.api_version</code></td><td>string</td><td>Recommended API version for Azure OpenAI SDK calls.</td></tr>
             <tr><td><code>models[].endpoints.azure_openai.url</code></td><td>string</td><td>Full URL for this deployment&rsquo;s chat completions via Azure OpenAI SDK format.</td></tr>

--- a/docs/_pages/services.html
+++ b/docs/_pages/services.html
@@ -110,6 +110,12 @@
             <td>150,000 TPM</td>
         </tr>
         <tr>
+            <td><strong>gpt-5.1</strong></td>
+            <td><span class="badge" style="background:#0f766e;color:white;">Provisioned Chat</span></td>
+            <td>Provisioned GPT-5.1 base model for sustained tenant workloads</td>
+            <td>4,750 input TPM/PTU; output weighted 8x</td>
+        </tr>
+        <tr>
             <td><strong>gpt-5.1-chat</strong></td>
             <td><span class="badge" style="background:#0369a1;color:white;">Chat Preview</span></td>
             <td>Next-gen preview chat model</td>
@@ -181,6 +187,13 @@
     <div class="alert-icon">💡</div>
     <div>
         TPM = Tokens Per Minute. OpenAI quotas shown above are <strong>subscription-wide limits</strong>; each tenant is allocated a share. Current test/dev allocation is typically <strong>1% per tenant</strong>, but provider-specific deployments can use different quotas. See <a href="infra-ai-hub/model-deployments.md">model-deployments.md</a> for the current allocation source of truth.
+    </div>
+</div>
+
+<div class="alert alert-info" style="margin-top: 1rem;">
+    <div class="alert-icon">💡</div>
+    <div>
+        Provisioned throughput uses <strong>input-equivalent</strong> TPM, not a simple raw input + output token total. For GPT-5.1, one output token counts as roughly eight input tokens toward PTU utilization, so the APIM safeguard uses a lower raw-token cap than the Foundry PTU ceiling.
     </div>
 </div>
 

--- a/docs/apim-internal-endpoints.html
+++ b/docs/apim-internal-endpoints.html
@@ -1200,10 +1200,16 @@
     <p>Returns the tenant's deployed AI models (with quota information) and the set of enabled AI services. The response is <strong>fully static</strong> &mdash; data is baked in at Terraform deploy time via <code>templatefile()</code>, so no Key Vault or backend calls are made at runtime. Always available; there is no feature flag that disables this endpoint.</p>
     <p>Use this endpoint to:</p>
     <ul>
-        <li>Discover which models are available and their per-model token-per-minute quota.</li>
+        <li>Discover which models are available, the APIM raw-token cap for each model, and any provisioned-throughput metadata.</li>
         <li>Confirm which AI services (Document Intelligence, AI Search, Speech, etc.) are enabled for your tenant.</li>
         <li>Drive UI dropdowns or config auto-discovery without maintaining a separate config file.</li>
     </ul>
+</div>
+
+<div class="alert alert-info">
+    <div>
+        <strong>Provisioned throughput note:</strong> For provisioned models, Microsoft Foundry measures throughput as <em>input-equivalent</em> tokens per minute, and some models weight output tokens more heavily than input tokens. APIM's <code>llm-token-limit</code> policy only enforces raw prompt + completion tokens, so the platform publishes both values and uses a conservative APIM cap to avoid Foundry rejecting requests earlier than APIM. For WLRS <code>gpt-5.1</code>, the Foundry ceiling is <code>71,250</code> input-equivalent TPM, the output weighting is <code>8x</code>, and the conservative APIM raw-token cap is therefore <code>8,906</code> TPM.
+    </div>
 </div>
 
 <div class="card">
@@ -1234,41 +1240,53 @@
   "base_url": "https://aihub.gov.bc.ca/wlrs-water-form-assistant",
   "models": [
     {
-      "name": "gpt-4.1-mini",
-      "model_name": "gpt-4.1-mini",
-      "model_version": "2025-04-14",
-      "scale_type": "GlobalStandard",
-      "capacity_k_tpm": 1500,
-      "tokens_per_minute": 1500000,
+            "name": "gpt-5.1",
+            "model_name": "gpt-5.1",
+            "model_version": "2025-11-13",
+            "scale_type": "GlobalProvisionedManaged",
+            "capacity": 15,
+            "capacity_unit": "PTU",
+            "capacity_k_tpm": null,
+            "input_tpm_per_ptu": 4750,
+            "output_tokens_to_input_ratio": 8,
+            "apim_raw_tokens_per_minute": 8906,
+            "input_equivalent_tokens_per_minute": 71250,
+            "tokens_per_minute": 8906,
       "endpoints": {
         "azure_openai": {
           "endpoint": "https://aihub.gov.bc.ca/wlrs-water-form-assistant",
           "api_version": "2025-03-01-preview",
-          "url": "https://aihub.gov.bc.ca/wlrs-water-form-assistant/openai/deployments/gpt-4.1-mini/chat/completions?api-version=2025-03-01-preview"
+                    "url": "https://aihub.gov.bc.ca/wlrs-water-form-assistant/openai/deployments/gpt-5.1/chat/completions?api-version=2025-03-01-preview"
         },
         "openai_compatible": {
           "base_url": "https://aihub.gov.bc.ca/wlrs-water-form-assistant/openai/v1",
-          "model": "gpt-4.1-mini",
+                    "model": "gpt-5.1",
           "url": "https://aihub.gov.bc.ca/wlrs-water-form-assistant/openai/v1/chat/completions"
         }
       }
     },
     {
-      "name": "gpt-4.1",
-      "model_name": "gpt-4.1",
+            "name": "gpt-4.1-mini",
+            "model_name": "gpt-4.1-mini",
       "model_version": "2025-04-14",
       "scale_type": "GlobalStandard",
-      "capacity_k_tpm": 300,
-      "tokens_per_minute": 300000,
+            "capacity": 1500,
+            "capacity_unit": "k TPM",
+            "capacity_k_tpm": 1500,
+            "input_tpm_per_ptu": null,
+            "output_tokens_to_input_ratio": null,
+            "apim_raw_tokens_per_minute": 1500000,
+            "input_equivalent_tokens_per_minute": 1500000,
+            "tokens_per_minute": 1500000,
       "endpoints": {
         "azure_openai": {
           "endpoint": "https://aihub.gov.bc.ca/wlrs-water-form-assistant",
           "api_version": "2025-03-01-preview",
-          "url": "https://aihub.gov.bc.ca/wlrs-water-form-assistant/openai/deployments/gpt-4.1/chat/completions?api-version=2025-03-01-preview"
+                    "url": "https://aihub.gov.bc.ca/wlrs-water-form-assistant/openai/deployments/gpt-4.1-mini/chat/completions?api-version=2025-03-01-preview"
         },
         "openai_compatible": {
           "base_url": "https://aihub.gov.bc.ca/wlrs-water-form-assistant/openai/v1",
-          "model": "gpt-4.1",
+                    "model": "gpt-4.1-mini",
           "url": "https://aihub.gov.bc.ca/wlrs-water-form-assistant/openai/v1/chat/completions"
         }
       }
@@ -1317,8 +1335,14 @@
             <tr><td><code>models[].model_name</code></td><td>string</td><td>Underlying Azure OpenAI model name.</td></tr>
             <tr><td><code>models[].model_version</code></td><td>string</td><td>Model version date string.</td></tr>
             <tr><td><code>models[].scale_type</code></td><td>string</td><td>Deployment scale type (e.g., <code>GlobalStandard</code>).</td></tr>
-            <tr><td><code>models[].capacity_k_tpm</code></td><td>number</td><td>Allocated quota in thousands of tokens per minute (from <code>tenant.tfvars</code>).</td></tr>
-            <tr><td><code>models[].tokens_per_minute</code></td><td>number</td><td>Computed TPM limit applied by rate-limiting (<code>capacity_k_tpm &times; 1000</code>).</td></tr>
+            <tr><td><code>models[].capacity</code></td><td>number</td><td>Raw capacity value from <code>tenant.tfvars</code>. This is expressed in <code>capacity_unit</code>.</td></tr>
+            <tr><td><code>models[].capacity_unit</code></td><td>string</td><td>Capacity unit for the deployment. Current values are <code>k TPM</code> for quota-based deployments and <code>PTU</code> for provisioned deployments.</td></tr>
+            <tr><td><code>models[].capacity_k_tpm</code></td><td>number|null</td><td>Allocated quota in thousands of tokens per minute for quota-based deployments. <code>null</code> for provisioned deployments.</td></tr>
+            <tr><td><code>models[].input_tpm_per_ptu</code></td><td>number|null</td><td>Model-specific input TPM available per PTU for provisioned deployments. <code>null</code> for quota-based deployments.</td></tr>
+            <tr><td><code>models[].output_tokens_to_input_ratio</code></td><td>number|null</td><td>For provisioned deployments, how many input-equivalent tokens one output token consumes. <code>null</code> for quota-based deployments.</td></tr>
+            <tr><td><code>models[].apim_raw_tokens_per_minute</code></td><td>number</td><td>The raw prompt + completion token cap enforced by APIM's <code>llm-token-limit</code> policy. For provisioned deployments this is a conservative ceiling chosen so APIM does not allow traffic that Foundry would reject sooner.</td></tr>
+            <tr><td><code>models[].input_equivalent_tokens_per_minute</code></td><td>number</td><td>The Foundry throughput ceiling expressed in input-equivalent tokens per minute. For quota-based deployments this matches the APIM cap. For provisioned deployments this is typically higher than the APIM raw-token cap because output tokens are weighted more heavily.</td></tr>
+            <tr><td><code>models[].tokens_per_minute</code></td><td>number</td><td>Legacy alias for <code>apim_raw_tokens_per_minute</code>. Use the explicit fields above for new consumers.</td></tr>
             <tr><td><code>models[].endpoints.azure_openai.endpoint</code></td><td>string</td><td>Endpoint for the Azure OpenAI SDK (<code>AzureOpenAI(azure_endpoint=...)</code>).</td></tr>
             <tr><td><code>models[].endpoints.azure_openai.api_version</code></td><td>string</td><td>Recommended API version for Azure OpenAI SDK calls.</td></tr>
             <tr><td><code>models[].endpoints.azure_openai.url</code></td><td>string</td><td>Full URL for this deployment&rsquo;s chat completions via Azure OpenAI SDK format.</td></tr>

--- a/docs/services.html
+++ b/docs/services.html
@@ -1186,6 +1186,12 @@
             <td>150,000 TPM</td>
         </tr>
         <tr>
+            <td><strong>gpt-5.1</strong></td>
+            <td><span class="badge" style="background:#0f766e;color:white;">Provisioned Chat</span></td>
+            <td>Provisioned GPT-5.1 base model for sustained tenant workloads</td>
+            <td>4,750 input TPM/PTU; output weighted 8x</td>
+        </tr>
+        <tr>
             <td><strong>gpt-5.1-chat</strong></td>
             <td><span class="badge" style="background:#0369a1;color:white;">Chat Preview</span></td>
             <td>Next-gen preview chat model</td>
@@ -1257,6 +1263,13 @@
     <div class="alert-icon">💡</div>
     <div>
         TPM = Tokens Per Minute. OpenAI quotas shown above are <strong>subscription-wide limits</strong>; each tenant is allocated a share. Current test/dev allocation is typically <strong>1% per tenant</strong>, but provider-specific deployments can use different quotas. See <a href="infra-ai-hub/model-deployments.md">model-deployments.md</a> for the current allocation source of truth.
+    </div>
+</div>
+
+<div class="alert alert-info" style="margin-top: 1rem;">
+    <div class="alert-icon">💡</div>
+    <div>
+        Provisioned throughput uses <strong>input-equivalent</strong> TPM, not a simple raw input + output token total. For GPT-5.1, one output token counts as roughly eight input tokens toward PTU utilization, so the APIM safeguard uses a lower raw-token cap than the Foundry PTU ceiling.
     </div>
 </div>
 

--- a/infra-ai-hub/model-deployments.md
+++ b/infra-ai-hub/model-deployments.md
@@ -4,7 +4,8 @@
 > See [IaC Coder Skills](../.github/skills/iac-coder/SKILL.md) for the mandatory update rule.
 
 This document tracks the OpenAI model capacity allocated to each tenant across all environments.
-Capacity values are in **thousands of Tokens Per Minute (TPM)** — the Azure OpenAI deployment unit.
+Capacity values for **GlobalStandard** deployments are in **thousands of Tokens Per Minute (TPM)**.
+Provisioned deployments use **PTU** instead, and their effective input TPM depends on the model-specific PTU throughput table published by Microsoft Learn.
 Percentage values show the share of the regional quota limit consumed by each tenant.
 
 ## Regional Quota Limits (Canada East)
@@ -60,6 +61,8 @@ Mistral models are serverless MaaS (pay-per-token). The Foundry deployment UI re
 
 Quota allocation strategy: **1% per tenant** for all models.
 
+The table below covers the quota-based **GlobalStandard** deployments. Provisioned deployments are listed separately because their capacity is measured in PTU, not k TPM.
+
 | Model | Quota Limit | wlrs (1%) | sdpr (1%) | nr-dap (1%) | gcpe (1%) | ai-hub-admin (1%) | Total (5%) | Remaining |
 |-------|------------:|----------:|----------:|------------:|----------:|------------------:|-----------:|----------:|
 | gpt-4.1 | 30,000 | 300 | 300 | 300 | 300 | 300 | 1,500 (5%) | 28,500 |
@@ -77,6 +80,15 @@ Quota allocation strategy: **1% per tenant** for all models.
 | text-embedding-ada-002 | 10,000 | 100 | 100 | 100 | 100 | 100 | 500 (5%) | 9,500 |
 | text-embedding-3-large | 10,000 | 100 | 100 | 100 | 100 | 100 | 500 (5%) | 9,500 |
 | text-embedding-3-small | 10,000 | 100 | 100 | 100 | 100 | 100 | 500 (5%) | 9,500 |
+
+### TEST Provisioned Deployments
+
+| Tenant | Deployment | Model | Scale Type | Capacity | Input TPM per PTU | Output Weight | Effective input-equivalent TPM | Conservative APIM raw TPM cap |
+|-------|------------|-------|------------|---------:|------------------:|--------------:|-------------------------------:|------------------------------:|
+| wlrs | gpt-5.1 | gpt-5.1 | GlobalProvisionedManaged | 15 PTU | 4,750 | 8x | 71,250 | 8,906 |
+
+The conservative APIM raw token cap is calculated as `floor(input_equivalent_tokens_per_minute / output_tokens_to_input_ratio)`.
+For GPT-5.1, APIM cannot enforce Foundry's output-weighted PTU accounting directly, so it uses `floor(71,250 / 8) = 8,906` raw tokens per minute to avoid Foundry accepting less traffic than APIM.
 
 ### Cohere Models (ai-hub-admin only)
 

--- a/infra-ai-hub/params/apim/api_policy.xml.tftpl
+++ b/infra-ai-hub/params/apim/api_policy.xml.tftpl
@@ -11,7 +11,7 @@
         </set-header>
 %{ if openai_enabled && rate_limiting_enabled ~}
         <!-- Per-model token rate limiting for OpenAI requests only -->
-        <!-- Each model has its own rate limit matching its Azure OpenAI deployment capacity -->
+        <!-- Each model has its own computed TPM limit based on its deployment type -->
         <!-- Only applies to /openai/* paths; DocInt/Speech/Search/Storage are not rate-limited by token count -->
         <!-- CRITICAL: estimate-prompt-tokens reads the entire request body for tokenization. -->
         <!-- On large binary payloads (e.g., 500KB base64 DocInt images) this causes APIM to hang. -->
@@ -40,10 +40,10 @@
                 <choose>
 %{ for model in model_deployments ~}
                     <when condition="@(context.Variables.GetValueOrDefault&lt;string&gt;(&quot;deploymentName&quot;, &quot;&quot;) == &quot;${model.name}&quot;)">
-                        <!-- Rate limit for ${model.name}: ${model.capacity}k TPM (deployment capacity is in thousands of TPM) -->
+                        <!-- Rate limit for ${model.name}: ${model.apim_raw_tokens_per_minute} raw TPM -->
                         <llm-token-limit
                             counter-key="@(context.Subscription.Id + &quot;-${model.name}&quot;)"
-                            tokens-per-minute="${model.capacity * 1000}"
+                            tokens-per-minute="${model.apim_raw_tokens_per_minute}"
                             estimate-prompt-tokens="true"
                             remaining-tokens-variable-name="remainingTokens"
                             remaining-tokens-header-name="x-ratelimit-remaining-tokens"
@@ -225,12 +225,18 @@
   tenant = tenant_name
   base_url = "${base_url}/${tenant_name}"
   models = [for m in model_deployments : {
-    name              = m.name
-    model_name        = m.model_name
-    model_version     = m.model_version
-    scale_type        = m.scale_type
-    capacity_k_tpm    = m.capacity
-    tokens_per_minute = m.capacity * 1000
+    name                               = m.name
+    model_name                         = m.model_name
+    model_version                      = m.model_version
+    scale_type                         = m.scale_type
+    capacity                           = m.capacity
+    capacity_unit                      = m.capacity_unit
+    capacity_k_tpm                     = m.capacity_k_tpm
+    input_tpm_per_ptu                  = m.input_tpm_per_ptu
+    output_tokens_to_input_ratio       = m.output_tokens_to_input_ratio
+    apim_raw_tokens_per_minute         = m.apim_raw_tokens_per_minute
+    input_equivalent_tokens_per_minute = m.input_equivalent_tokens_per_minute
+    tokens_per_minute                  = m.tokens_per_minute
     endpoints = {
       azure_openai = {
         endpoint    = "${base_url}/${tenant_name}"

--- a/infra-ai-hub/params/test/tenants/wlrs-water-form-assistant/tenant.tfvars
+++ b/infra-ai-hub/params/test/tenants/wlrs-water-form-assistant/tenant.tfvars
@@ -91,7 +91,9 @@ tenant = {
       log_categories    = []
       metric_categories = ["AllMetrics"]
     }
-    # Capacity = 1% of regional quota limit per model
+    # Capacity uses model-specific units:
+    # - GlobalStandard deployments use 1% of the regional TPM quota per model
+    # - Provisioned deployments use PTUs and Azure's per-model PTU throughput table
     # Quota limits: gpt-4.1=30k, gpt-4.1-mini=150k, gpt-4.1-nano=150k,
     #   gpt-4o=30k, gpt-4o-mini=150k, gpt-5-mini=10k, gpt-5-nano=150k,
     #   gpt-5.1-chat=5k, gpt-5.1-codex-mini=10k, o1=5k, o3-mini=5k,
@@ -190,6 +192,14 @@ tenant = {
         model_version  = "2025-11-13"
         scale_type     = "GlobalStandard"
         capacity       = 100 # 1% of 10,000
+        content_filter = { base_policy_name = "Microsoft.DefaultV2", filters = [] }
+      },
+      {
+        name           = "gpt-5.1"
+        model_name     = "gpt-5.1"
+        model_version  = "2025-11-13"
+        scale_type     = "GlobalProvisionedManaged"
+        capacity       = 15 # 4,750 input TPM/PTU => 71,250 input TPM
         content_filter = { base_policy_name = "Microsoft.DefaultV2", filters = [] }
       },
       # Reasoning Models

--- a/infra-ai-hub/stacks/apim/locals.tf
+++ b/infra-ai-hub/stacks/apim/locals.tf
@@ -102,13 +102,61 @@ locals {
     "https://${lookup(var.shared_config.app_gateway, "frontend_hostname", "")}"
   ) : (local.apim_config.enabled ? module.apim[0].gateway_url : "")
 
+  provisioned_scale_types = toset([
+    "GlobalProvisionedManaged",
+    "DataZoneProvisionedManaged",
+    "ProvisionedManaged",
+  ])
+
+  # Azure OpenAI provisioned throughput uses model-specific input TPM per PTU,
+  # and some models weight output tokens more heavily than input tokens.
+  # Sources:
+  # - https://learn.microsoft.com/en-us/azure/foundry/openai/how-to/provisioned-throughput-onboarding#latest-azure-openai-models
+  # - https://azure.microsoft.com/en-ca/pricing/details/cognitive-services/openai-service/
+  provisioned_capacity_metadata_by_model = {
+    "gpt-5.1" = {
+      input_tpm_per_ptu            = 4750
+      output_tokens_to_input_ratio = 8
+    }
+  }
+
   tenant_api_policies = {
     for key, config in local.enabled_tenants : key => templatefile(
       "${path.root}/../../params/apim/api_policy.xml.tftpl",
       {
-        tenant_name                    = key
-        tokens_per_minute              = try(config.apim_policies.rate_limiting.tokens_per_minute, 10000)
-        model_deployments              = try(config.openai.model_deployments, [])
+        tenant_name       = key
+        tokens_per_minute = try(config.apim_policies.rate_limiting.tokens_per_minute, 10000)
+        model_deployments = [
+          for _m in [
+            for deployment in try(config.openai.model_deployments, []) : merge(deployment, {
+              # Quota-backed deployments report capacity directly in k TPM; provisioned deployments use PTU.
+              capacity_unit = contains(local.provisioned_scale_types, try(deployment.scale_type, "")) ? "PTU" : "k TPM"
+              # Preserve the legacy k TPM field for quota-backed deployments only.
+              capacity_k_tpm = contains(local.provisioned_scale_types, try(deployment.scale_type, "")) ? null : try(deployment.capacity, null)
+              # PTU metadata is model-specific and comes from the lookup table above.
+              input_tpm_per_ptu            = contains(local.provisioned_scale_types, try(deployment.scale_type, "")) ? try(local.provisioned_capacity_metadata_by_model[try(deployment.model_name, deployment.name)].input_tpm_per_ptu, null) : null
+              output_tokens_to_input_ratio = contains(local.provisioned_scale_types, try(deployment.scale_type, "")) ? try(local.provisioned_capacity_metadata_by_model[try(deployment.model_name, deployment.name)].output_tokens_to_input_ratio, null) : null
+              # Foundry PTU throughput is tracked in input-equivalent TPM, not raw prompt+completion tokens.
+              input_equivalent_tokens_per_minute = contains(local.provisioned_scale_types, try(deployment.scale_type, "")) ? (
+                try(deployment.capacity, 0) * try(local.provisioned_capacity_metadata_by_model[try(deployment.model_name, deployment.name)].input_tpm_per_ptu, 1000)
+              ) : (try(deployment.capacity, 0) * 1000)
+              # APIM can only rate-limit raw tokens, so convert the PTU ceiling into a conservative
+              # raw-token cap by dividing the input-equivalent ceiling by the output weighting ratio.
+              apim_raw_tokens_per_minute = contains(local.provisioned_scale_types, try(deployment.scale_type, "")) ? floor(
+                (
+                  try(deployment.capacity, 0) *
+                  try(local.provisioned_capacity_metadata_by_model[try(deployment.model_name, deployment.name)].input_tpm_per_ptu, 1000)
+                  ) / max(
+                  1,
+                  try(local.provisioned_capacity_metadata_by_model[try(deployment.model_name, deployment.name)].output_tokens_to_input_ratio, 1)
+                )
+              ) : (try(deployment.capacity, 0) * 1000)
+            })
+            ] : merge(_m, {
+              # Legacy alias: kept aligned with the actual APIM-enforced raw-token cap.
+              tokens_per_minute = _m.apim_raw_tokens_per_minute
+          })
+        ]
         openai_enabled                 = length(try(config.openai.model_deployments, [])) > 0
         document_intelligence_enabled  = try(config.document_intelligence.enabled, false)
         ai_search_enabled              = try(config.ai_search.enabled, false)
@@ -187,5 +235,21 @@ locals {
   # ---------------------------------------------------------------------------
   monitoring_config = {
     enabled = lookup(lookup(var.shared_config, "monitoring", {}), "enabled", false)
+  }
+}
+
+# Advisory check: warn if a provisioned deployment references a model not in
+# the provisioned_capacity_metadata_by_model lookup table (silent fallback to
+# 1000 / 1 would produce incorrect rate-limit values).
+check "provisioned_model_metadata_coverage" {
+  assert {
+    condition = alltrue([
+      for key, config in local.enabled_tenants : alltrue([
+        for deployment in try(config.openai.model_deployments, []) :
+        !contains(local.provisioned_scale_types, try(deployment.scale_type, "")) ||
+        contains(keys(local.provisioned_capacity_metadata_by_model), try(deployment.model_name, deployment.name))
+      ])
+    ])
+    error_message = "One or more provisioned deployments reference a model not in provisioned_capacity_metadata_by_model. Add the model's input_tpm_per_ptu and output_tokens_to_input_ratio to the lookup table in locals.tf."
   }
 }

--- a/tenant-onboarding-portal/backend/src/app.controller.ts
+++ b/tenant-onboarding-portal/backend/src/app.controller.ts
@@ -534,16 +534,37 @@ export class AppController {
    * @returns Formatted capacity string.
    */
   private formatTenantInfoCapacity(model: RawApimTenantInfoModel): string {
+    const formatter = new Intl.NumberFormat('en-CA');
+    const apimRawTokensPerMinute =
+      model.apim_raw_tokens_per_minute ?? model.tokens_per_minute ?? undefined;
+    const inputEquivalentTokensPerMinute =
+      model.input_equivalent_tokens_per_minute ?? model.tokens_per_minute ?? undefined;
+
+    if (model.capacity_unit === 'PTU' && typeof model.capacity === 'number') {
+      if (
+        typeof inputEquivalentTokensPerMinute === 'number' &&
+        typeof apimRawTokensPerMinute === 'number'
+      ) {
+        return `${formatter.format(model.capacity)} PTU (${formatter.format(inputEquivalentTokensPerMinute)} input-equivalent TPM; APIM cap ${formatter.format(apimRawTokensPerMinute)} raw TPM)`;
+      }
+
+      if (typeof inputEquivalentTokensPerMinute === 'number') {
+        return `${formatter.format(model.capacity)} PTU (${formatter.format(inputEquivalentTokensPerMinute)} input-equivalent TPM)`;
+      }
+
+      return `${formatter.format(model.capacity)} PTU`;
+    }
+
     if (typeof model.capacity_k_tpm === 'number') {
       return `${model.capacity_k_tpm}k TPM`;
     }
 
-    if (typeof model.tokens_per_minute === 'number') {
-      return `${new Intl.NumberFormat('en-CA').format(model.tokens_per_minute)} TPM`;
+    if (typeof apimRawTokensPerMinute === 'number') {
+      return `${formatter.format(apimRawTokensPerMinute)} TPM`;
     }
 
     if (typeof model.capacity === 'number') {
-      return new Intl.NumberFormat('en-CA').format(model.capacity);
+      return formatter.format(model.capacity);
     }
 
     return 'Not available';

--- a/tenant-onboarding-portal/backend/src/types.ts
+++ b/tenant-onboarding-portal/backend/src/types.ts
@@ -132,7 +132,12 @@ export interface RawApimTenantInfoModel {
   scale_type?: string;
   deployment?: string;
   capacity?: number;
+  capacity_unit?: string;
   capacity_k_tpm?: number;
+  input_tpm_per_ptu?: number;
+  output_tokens_to_input_ratio?: number;
+  apim_raw_tokens_per_minute?: number;
+  input_equivalent_tokens_per_minute?: number;
   tokens_per_minute?: number;
   endpoints?: {
     azure_openai?: {

--- a/tests/integration/tenant-info.bats
+++ b/tests/integration/tenant-info.bats
@@ -127,7 +127,7 @@ post_tenant_info() {
 
     assert_status "200" "${RESPONSE_STATUS}"
 
-    # Every model must carry all six required fields and none may be null/empty
+    # Every model must carry the common fields plus either kTPM or PTU metadata.
     local invalid_count
     invalid_count=$(echo "${RESPONSE_BODY}" | jq '[
         .models[] | select(
@@ -135,14 +135,20 @@ post_tenant_info() {
             (.model_name    | (. == null or length == 0)) or
             (.model_version | (. == null or length == 0)) or
             (.scale_type    | (. == null or length == 0)) or
-            (.capacity_k_tpm   == null) or
-            (.tokens_per_minute == null)
+            (.tokens_per_minute == null) or
+            (.apim_raw_tokens_per_minute == null) or
+            (.input_equivalent_tokens_per_minute == null) or
+            (if .capacity_unit == "PTU" then
+                (.capacity == null or .input_tpm_per_ptu == null or .output_tokens_to_input_ratio == null)
+             else
+                (.capacity_k_tpm == null)
+             end)
         )
     ] | length')
     [[ "${invalid_count}" -eq 0 ]]
 }
 
-@test "Tenant-1: tenant-info tokens_per_minute equals capacity_k_tpm * 1000 for every model" {
+@test "Tenant-1: tenant-info rate-limit metadata matches the model capacity metadata" {
     local t1
     t1="$(tenant_1)"
     skip_if_no_key "${t1}"
@@ -154,9 +160,49 @@ post_tenant_info() {
 
     local mismatch_count
     mismatch_count=$(echo "${RESPONSE_BODY}" | jq '[
-        .models[] | select(.tokens_per_minute != (.capacity_k_tpm * 1000))
+        .models[] | select(
+            if .capacity_unit == "PTU" then
+                .input_equivalent_tokens_per_minute != (.capacity * .input_tpm_per_ptu) or
+                .apim_raw_tokens_per_minute != ((.input_equivalent_tokens_per_minute / .output_tokens_to_input_ratio) | floor) or
+                .tokens_per_minute != .apim_raw_tokens_per_minute
+            else
+                .tokens_per_minute != (.capacity_k_tpm * 1000) or
+                .apim_raw_tokens_per_minute != (.capacity_k_tpm * 1000) or
+                .input_equivalent_tokens_per_minute != (.capacity_k_tpm * 1000)
+            end
+        )
     ] | length')
     [[ "${mismatch_count}" -eq 0 ]]
+}
+
+@test "Tenant-1 (wlrs): gpt-5.1 PTU deployment reports the correct throughput" {
+    local t1
+    t1="$(tenant_1)"
+    skip_if_no_key "${t1}"
+
+    response=$(get_tenant_info "${t1}")
+    parse_response "${response}"
+
+    assert_status "200" "${RESPONSE_STATUS}"
+
+    local scale_type capacity capacity_unit input_tpm_per_ptu output_tokens_to_input_ratio apim_raw_tokens_per_minute input_equivalent_tokens_per_minute tokens_per_minute
+    scale_type=$(json_get "${RESPONSE_BODY}" '.models[] | select(.name == "gpt-5.1") | .scale_type')
+    capacity=$(json_get "${RESPONSE_BODY}" '.models[] | select(.name == "gpt-5.1") | .capacity')
+    capacity_unit=$(json_get "${RESPONSE_BODY}" '.models[] | select(.name == "gpt-5.1") | .capacity_unit')
+    input_tpm_per_ptu=$(json_get "${RESPONSE_BODY}" '.models[] | select(.name == "gpt-5.1") | .input_tpm_per_ptu')
+    output_tokens_to_input_ratio=$(json_get "${RESPONSE_BODY}" '.models[] | select(.name == "gpt-5.1") | .output_tokens_to_input_ratio')
+    apim_raw_tokens_per_minute=$(json_get "${RESPONSE_BODY}" '.models[] | select(.name == "gpt-5.1") | .apim_raw_tokens_per_minute')
+    input_equivalent_tokens_per_minute=$(json_get "${RESPONSE_BODY}" '.models[] | select(.name == "gpt-5.1") | .input_equivalent_tokens_per_minute')
+    tokens_per_minute=$(json_get "${RESPONSE_BODY}" '.models[] | select(.name == "gpt-5.1") | .tokens_per_minute')
+
+    [[ "${scale_type}" == "GlobalProvisionedManaged" ]]
+    [[ "${capacity}" == "15" ]]
+    [[ "${capacity_unit}" == "PTU" ]]
+    [[ "${input_tpm_per_ptu}" == "4750" ]]
+    [[ "${output_tokens_to_input_ratio}" == "8" ]]
+    [[ "${apim_raw_tokens_per_minute}" == "8906" ]]
+    [[ "${input_equivalent_tokens_per_minute}" == "71250" ]]
+    [[ "${tokens_per_minute}" == "8906" ]]
 }
 
 @test "Tenant-1: tenant-info contains services object with all required keys" {
@@ -296,8 +342,16 @@ post_tenant_info() {
         .models[] | select(
             (.name | (. == null or length == 0)) or
             (.model_name | (. == null or length == 0)) or
-            (.capacity_k_tpm == null) or
-            (.tokens_per_minute == null)
+            (.model_version | (. == null or length == 0)) or
+            (.scale_type | (. == null or length == 0)) or
+            (.tokens_per_minute == null) or
+            (.apim_raw_tokens_per_minute == null) or
+            (.input_equivalent_tokens_per_minute == null) or
+            (if .capacity_unit == "PTU" then
+                (.capacity == null or .input_tpm_per_ptu == null or .output_tokens_to_input_ratio == null)
+             else
+                (.capacity_k_tpm == null)
+             end)
         )
     ] | length')
     [[ "${invalid_count}" -eq 0 ]]


### PR DESCRIPTION


<!-- ai-hub-infra-changes -->
## AI Hub Infra Changes

**Summary:** 1 to add, 19 to change, 1 to destroy (across 5 stack(s))

<details><summary>Show plan details</summary>

```hcl
Terraform will perform the following actions:

  # module.hub_key_vault.azurerm_role_assignment.this["deployer_secrets_officer"] must be replaced
-/+ resource "azurerm_role_assignment" "this" {
      + condition_version                      = (known after apply)
      ~ id                                     = "/subscriptions/****/resourceGroups/ai-services-hub-test/providers/Microsoft.KeyVault/vaults/ai-services-hub-test-hkv/providers/Microsoft.Authorization/roleAssignments/****" -> (known after apply)
      ~ name                                   = "****" -> (known after apply)
      ~ principal_id                           = "****" -> "****" # forces replacement
      ~ principal_type                         = "User" -> (known after apply)
      ~ role_definition_id                     = "/subscriptions/****/providers/Microsoft.Authorization/roleDefinitions/****" -> (known after apply)
        # (6 unchanged attributes hidden)
    }

Plan: 1 to add, 0 to change, 1 to destroy.

Warning: Argument is deprecated

  with module.hub_key_vault.azurerm_key_vault.this,
  on .terraform/modules/hub_key_vault/main.tf line 7, in resource "azurerm_key_vault" "this":
   7:   enable_rbac_authorization       = !var.legacy_access_policies_enabled

This property has been renamed to `rbac_authorization_enabled` and will be
removed in v5.0 of the provider

─────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't
guarantee to take exactly these actions if you run "terraform apply" now.
Releasing state lock. This may take a few moments...
2026-03-31T01:36:41Z [SUCCESS] terraform plan (shared) (attempt 1/5) completed successfully
2026-03-31T01:36:43Z [INFO] Running 5 tenants in parallel
2026-03-31T01:36:43Z [INFO] Starting terraform init (tenant:ai-hub-admin)
Initializing the backend...

Successfully configured the backend "azurerm"! Terraform will automatically
use this backend unless the backend configuration changes.
Upgrading modules...
- tenant in ../../modules/tenant
Downloading registry.terraform.io/Azure/avm-res-search-searchservice/azurerm 0.2.0 for tenant.ai_search...
- tenant.ai_search in /home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-ai-hub-admin/modules/tenant.ai_search
Downloading registry.terraform.io/Azure/avm-res-cognitiveservices-account/azurerm 0.7.1 for tenant.document_intelligence...
- tenant.document_intelligence in /home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-ai-hub-admin/modules/tenant.document_intelligence
Downloading registry.terraform.io/Azure/avm-res-keyvault-vault/azurerm 0.10.2 for tenant.key_vault...
- tenant.key_vault in /home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-ai-hub-admin/modules/tenant.key_vault
- tenant.key_vault.keys in /home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-ai-hub-admin/modules/tenant.key_vault/modules/key
- tenant.key_vault.secrets in /home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-ai-hub-admin/modules/tenant.key_vault/modules/secret
Downloading registry.terraform.io/Azure/avm-res-cognitiveservices-account/azurerm 0.7.1 for tenant.speech_services...
- tenant.speech_services in /home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-ai-hub-admin/modules/tenant.speech_services
Initializing provider plugins...
- terraform.io/builtin/terraform is built in to Terraform
- Finding azure/azapi versions matching "~> 2.0, ~> 2.4, >= 2.5.0"...
- Finding hashicorp/null versions matching ">= 3.2.0"...
- Finding azure/modtm versions matching "~> 0.3"...
- Finding hashicorp/random versions matching ">= 3.5.0, ~> 3.5, >= 3.7.0, < 4.0.0"...
- Finding hashicorp/time versions matching "~> 0.9"...
- Finding hashicorp/azurerm versions matching ">= 3.117.0, ~> 4.0, >= 4.17.0, >= 4.38.0, < 5.0.0"...
- Installing hashicorp/azurerm v4.66.0...
- Installed hashicorp/azurerm v4.66.0 (signed by HashiCorp)
- Installing azure/azapi v2.9.0...
- Installed azure/azapi v2.9.0 (signed by a HashiCorp partner, key ID 6F0B91BDE98478CF)
- Installing hashicorp/null v3.2.4...
- Installed hashicorp/null v3.2.4 (signed by HashiCorp)
- Installing azure/modtm v0.3.5...
- Installed azure/modtm v0.3.5 (signed by a HashiCorp partner, key ID 6F0B91BDE98478CF)
- Installing hashicorp/random v3.8.1...
- Installed hashicorp/random v3.8.1 (signed by HashiCorp)
- Installing hashicorp/time v0.13.1...
- Installed hashicorp/time v0.13.1 (signed by HashiCorp)
Partner and community providers are signed by their developers.
If you'd like to know more about provider signing, you can read about it here:
https://developer.hashicorp.com/terraform/cli/plugins/signing
Terraform has created a lock file .terraform.lock.hcl to record the provider
selections it made above. Include this file in your version control repository
so that Terraform can guarantee to make the same selections by default when
you run "terraform init" in the future.

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
2026-03-31T01:36:53Z [SUCCESS] terraform init (tenant:ai-hub-admin) completed successfully
2026-03-31T01:36:53Z [INFO] Starting terraform plan (tenant:ai-hub-admin) (attempt 1/5)
Acquiring state lock. This may take a few moments...
2026-03-31T01:36:57.592Z [ERROR] AttachSchemaTransformer: No provider config schema available for provider["terraform.io/builtin/terraform"]
2026-03-31T01:36:59.492Z [ERROR] AttachSchemaTransformer: No provider config schema available for provider["terraform.io/builtin/terraform"]
module.tenant["ai-hub-admin"].random_string.suffix: Refreshing state... [id=418z]
data.terraform_remote_state.shared: Reading...
data.terraform_remote_state.shared: Read complete after 1s
module.tenant["ai-hub-admin"].data.azurerm_client_config.current: Reading...
module.tenant["ai-hub-admin"].azurerm_resource_group.tenant: Refreshing state... [id=/subscriptions/****/resourceGroups/ai-hub-admin-rg]
module.tenant["ai-hub-admin"].data.azurerm_client_config.current: Read complete after 0s [id=Y2xpZW50Q29uZmlncy9jbGllbnRJZD1kZmZiM2UzZC1kMjU5LTQ2NmUtODUwYS1kOTEyYTI1NGViNjM7b2JqZWN0SWQ9YjE0NTQ5NTItNTg4ZS00MzUzLTk3ZTAtMTVhY2MwZGViYjcyO3N1YnNjcmlwdGlvbklkPTM0YzVlNmQ4LTA2NjUtNDg3Ny04MGE1LThjMGY1N2IxNGIzMzt0ZW5hbnRJZD02ZmRiNTIwMC0zZDBkLTRhOGEtYjAzNi1kMzY4NWUzNTlhZGM=]
module.tenant["ai-hub-admin"].module.document_intelligence[0].random_string.default_custom_subdomain_name_suffix[0]: Refreshing state... [id=kczgc]
module.tenant["ai-hub-admin"].azurerm_log_analytics_workspace.tenant[0]: Refreshing state... [id=/subscriptions/****/resourceGroups/ai-hub-admin-rg/providers/Microsoft.OperationalInsights/workspaces/aihubadmin-law-418z]
module.tenant["ai-hub-admin"].azurerm_storage_account.this[0]: Refreshing state... [id=/subscriptions/****/resourceGroups/ai-hub-admin-rg/providers/Microsoft.Storage/storageAccounts/aihubadminst418z]
module.tenant["ai-hub-admin"].module.document_intelligence[0].azurerm_cognitive_account.this[0]: Refreshing state... [id=/subscriptions/****/resourceGroups/ai-hub-admin-rg/providers/Microsoft.CognitiveServices/accounts/ai-hub-admin-docint-418z]
module.tenant["ai-hub-admin"].module.document_intelligence[0].azurerm_private_endpoint.this_unmanaged_dns_zone_groups["primary"]: Refreshing state... [id=/subscriptions/****/resourceGroups/ai-hub-admin-rg/providers/Microsoft.Network/privateEndpoints/pep-ai-hub-admin-docint-418z]
module.tenant["ai-hub-admin"].azurerm_application_insights.tenant[0]: Refreshing state... [id=/subscriptions/****/resourceGroups/ai-hub-admin-rg/providers/Microsoft.Insights/components/aihubadmin-appi-418z]
module.tenant["ai-hub-admin"].azurerm_monitor_diagnostic_setting.document_intelligence[0]: Refreshing state... [id=/subscriptions/****/resourceGroups/ai-hub-admin-rg/providers/Microsoft.CognitiveServices/accounts/ai-hub-admin-docint-418z|ai-hub-admin-docint-diag]
module.tenant["ai-hub-admin"].null_resource.wait_for_dns_document_intelligence[0]: Refreshing state... [id=2996673960704066107]
module.tenant["ai-hub-admin"].azurerm_storage_container.default[0]: Refreshing state... [id=/subscriptions/****/resourceGroups/ai-hub-admin-rg/providers/Microsoft.Storage/storageAccounts/aihubadminst418z/blobServices/default/containers/default]
module.tenant["ai-hub-admin"].azurerm_monitor_diagnostic_setting.storage[0]: Refreshing state... [id=/subscriptions/****/resourceGroups/ai-hub-admin-rg/providers/Microsoft.Storage/storageAccounts/aihubadminst418z|ai-hub-admin-storage-diag]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration
and found no differences, so no changes are needed.

Warning: Value for undeclared variable

The root module does not declare a variable named "defender_resource_types"
but a value was found in file
"/home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/params/test/shared.tfvars".
If you meant to use this value, add a "variable" block to the configuration.

To silence these warnings, use TF_VAR_... environment variables to provide
certain "global" settings to all configurations in your organization. To
reduce the verbosity of these warnings, use the -compact-warnings option.

Warning: Value for undeclared variable

The root module does not declare a variable named "defender_enabled" but a
value was found in file
"/home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/params/test/shared.tfvars".
If you meant to use this value, add a "variable" block to the configuration.

To silence these warnings, use TF_VAR_... environment variables to provide
certain "global" settings to all configurations in your organization. To
reduce the verbosity of these warnings, use the -compact-warnings option.
Releasing state lock. This may take a few moments...
2026-03-31T01:37:10Z [SUCCESS] terraform plan (tenant:ai-hub-admin) (attempt 1/5) completed successfully
2026-03-31T01:37:11Z [SUCCESS] tenant:ai-hub-admin completed successfully
2026-03-31T01:36:43Z [INFO] Starting terraform init (tenant:gcpe-media-monitoring)
Initializing the backend...

Successfully configured the backend "azurerm"! Terraform will automatically
use this backend unless the backend configuration changes.
Upgrading modules...
- tenant in ../../modules/tenant
Downloading registry.terraform.io/Azure/avm-res-search-searchservice/azurerm 0.2.0 for tenant.ai_search...
- tenant.ai_search in /home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-gcpe-media-monitoring/modules/tenant.ai_search
Downloading registry.terraform.io/Azure/avm-res-cognitiveservices-account/azurerm 0.7.1 for tenant.document_intelligence...
- tenant.document_intelligence in /home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-gcpe-media-monitoring/modules/tenant.document_intelligence
Downloading registry.terraform.io/Azure/avm-res-keyvault-vault/azurerm 0.10.2 for tenant.key_vault...
- tenant.key_vault in /home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-gcpe-media-monitoring/modules/tenant.key_vault
- tenant.key_vault.keys in /home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-gcpe-media-monitoring/modules/tenant.key_vault/modules/key
- tenant.key_vault.secrets in /home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-gcpe-media-monitoring/modules/tenant.key_vault/modules/secret
Downloading registry.terra
(truncated, see workflow logs for complete plan)
```

</details>

---
_Updated by CI — plan against `test` environment (run [#326](https://github.com/bcgov/ai-hub-tracking/actions/runs/23776217029)) at 2026-03-31 01:39:07 UTC._
<!-- /ai-hub-infra-changes -->