### PR TITLE
fix: codeql alerts

### DIFF
--- a/docs/generate-search-index.js
+++ b/docs/generate-search-index.js
@@ -16,6 +16,15 @@
 
 const fs = require("fs");
 const path = require("path");
+const BASIC_ENTITY_REPLACEMENTS = {
+  "&lt;": "<",
+  "&gt;": ">",
+  "&quot;": '"',
+  "&#39;": "'",
+  "&nbsp;": " ",
+  "&amp;": "&",
+};
+const BASIC_ENTITY_RE = /&(lt|gt|quot|#39|nbsp|amp);/g;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -23,14 +32,9 @@ const path = require("path");
 
 /** Remove HTML tags and decode basic entities. */
 function stripHtml(html) {
-  return html
-    .replace(/<[^>]+>/g, " ")
-    .replace(/&amp;/g, "&")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/&nbsp;/g, " ");
+  return html.replace(/<[^>]+>/g, " ").replace(BASIC_ENTITY_RE, (match) => {
+    return BASIC_ENTITY_REPLACEMENTS[match] ?? match;
+  });
 }
 
 /** Collapse whitespace. */

--- a/jobs/apim-key-rotation/rotation/keyvault.py
+++ b/jobs/apim-key-rotation/rotation/keyvault.py
@@ -97,7 +97,7 @@ def store_key_in_vault(
         expires_on=expires_on,
         tags=tags or {},
     )
-    logger.debug("Stored key secret '%s' in hub KV", secret_name)
+    logger.debug("Stored APIM subscription key in hub KV")
 
 
 def verify_keyvault_exists(settings: Settings) -> bool:

--- a/jobs/apim-key-rotation/tests/test_keyvault.py
+++ b/jobs/apim-key-rotation/tests/test_keyvault.py
@@ -1,0 +1,37 @@
+# =============================================================================
+# Unit tests — Key Vault helper operations
+# =============================================================================
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import rotation.keyvault as keyvault_ops
+
+
+class TestStoreKeyInVault:
+    """Test subscription-key storage behavior."""
+
+    def test_store_key_does_not_log_secret_identifier_or_value(
+        self,
+        monkeypatch,
+        caplog,
+    ) -> None:
+        client = MagicMock()
+        settings = SimpleNamespace(secret_expiry_days=30)
+
+        monkeypatch.setattr(keyvault_ops, "_get_client", lambda _: client)
+        caplog.set_level(logging.DEBUG, logger="apim-key-rotation.keyvault")
+
+        keyvault_ops.store_key_in_vault(
+            settings,
+            "tenant-a-primary-key",
+            "super-secret-value",
+            tags={"tenant": "tenant-a"},
+        )
+
+        client.set_secret.assert_called_once()
+        assert "tenant-a-primary-key" not in caplog.text
+        assert "super-secret-value" not in caplog.text
+        assert "Stored APIM subscription key in hub KV" in caplog.text

--- a/tenant-onboarding-portal/backend/src/app.controller.ts
+++ b/tenant-onboarding-portal/backend/src/app.controller.ts
@@ -141,6 +141,17 @@ export class AppController {
   }
 
   /**
+   * Resolves an internal redirect-state token and redirects the browser to the stored target.
+   *
+   * @param response - The outgoing HTTP response used for the redirect.
+   * @param state - The short-lived redirect-state token from the auth service.
+   */
+  @Get('api/auth/redirect')
+  async authRedirect(@Res() response: Response, @Query('state') state?: string) {
+    await this.authSession.completeRedirect(response, state);
+  }
+
+  /**
    * Logs out the current user by deleting the portal session, clearing the session cookie,
    * and redirecting to the OIDC end-session endpoint.
    *

--- a/tenant-onboarding-portal/backend/src/auth/session.service.ts
+++ b/tenant-onboarding-portal/backend/src/auth/session.service.ts
@@ -9,13 +9,29 @@ import { createHash, randomBytes } from 'node:crypto';
 
 import { getSettings } from '../config/settings';
 import { SessionStoreService } from '../storage/session-store.service';
-import type { OidcTokenSet, PortalLoginState, PortalSessionRecord, PortalUser } from '../types';
+import type {
+  OidcTokenSet,
+  PortalLoginState,
+  PortalRedirectState,
+  PortalSessionRecord,
+  PortalUser,
+} from '../types';
 import { TokenValidatorService } from './token-validator.service';
 
 const SESSION_COOKIE_NAME = 'tenant-portal-session';
 const LOGIN_STATE_TTL_SECONDS = 10 * 60;
+const REDIRECT_STATE_TTL_SECONDS = 10 * 60;
 const MOCK_SESSION_TTL_SECONDS = 8 * 60 * 60;
 const SESSION_REFRESH_INTERVAL_MS = 2 * 60 * 1000;
+const RETURN_TO_ROUTE_PATTERNS = [
+  /^\/$/,
+  /^\/tenants$/,
+  /^\/tenants\/new$/,
+  /^\/tenants\/[A-Za-z0-9._~-]+$/,
+  /^\/tenants\/[A-Za-z0-9._~-]+\/edit$/,
+  /^\/admin\/dashboard$/,
+  /^\/admin\/review\/[A-Za-z0-9._~-]+\/[A-Za-z0-9._~-]+$/,
+];
 
 @Injectable()
 export class AuthSessionService {
@@ -79,7 +95,7 @@ export class AuthSessionService {
 
     if (settings.authMode === 'mock') {
       await this.createMockSession(response, request);
-      response.redirect(302, normalizedReturnTo);
+      await this.redirectToStoredTarget(response, normalizedReturnTo);
       return;
     }
 
@@ -156,6 +172,25 @@ export class AuthSessionService {
   }
 
   /**
+   * Completes an internal redirect callback by resolving a stored redirect-state token.
+   *
+   * This indirection keeps user-supplied `return_to` values out of direct redirect sinks while
+   * preserving deep-link behavior for login and logout flows.
+   *
+   * @param response - The outgoing HTTP response used for the redirect.
+   * @param state - The short-lived redirect-state token created earlier in the auth flow.
+   */
+  async completeRedirect(response: Response, state?: string): Promise<void> {
+    if (!state) {
+      response.redirect(302, '/');
+      return;
+    }
+
+    const redirectState = await this.sessionStore.consumeRedirectState(state);
+    response.redirect(302, redirectState?.returnTo ?? '/');
+  }
+
+  /**
    * Logs the current user out by deleting the server-side session and clearing the session cookie.
    *
    * When OIDC is active and the IdP exposes an end-session endpoint, the user is redirected
@@ -177,21 +212,23 @@ export class AuthSessionService {
     this.clearSessionCookie(response, request);
 
     if (getSettings().authMode !== 'oidc') {
-      response.redirect(302, normalizedReturnTo);
+      await this.redirectToStoredTarget(response, normalizedReturnTo);
       return;
     }
 
     const config = await this.tokenValidator.publicConfig();
     if (!config.endSessionEndpoint) {
-      response.redirect(302, normalizedReturnTo);
+      await this.redirectToStoredTarget(response, normalizedReturnTo);
       return;
     }
+
+    const redirectState = await this.createAndStoreRedirectState(normalizedReturnTo);
 
     const logoutUrl = new URL(config.endSessionEndpoint);
     logoutUrl.searchParams.set('client_id', config.clientId);
     logoutUrl.searchParams.set(
       'post_logout_redirect_uri',
-      this.absoluteUrl(request, normalizedReturnTo),
+      this.absoluteUrl(request, this.redirectStatePath(redirectState.state)),
     );
     if (session?.idToken) {
       logoutUrl.searchParams.set('id_token_hint', session.idToken);
@@ -276,6 +313,57 @@ export class AuthSessionService {
       createdAt: now.toISOString(),
       expiresAt: expiresAt.toISOString(),
     };
+  }
+
+  /**
+   * Creates a short-lived redirect-state record for a validated internal target path.
+   *
+   * @param returnTo - The validated internal path to use after the auth flow completes.
+   * @returns A new {@link PortalRedirectState} ready to be persisted.
+   */
+  private createRedirectState(returnTo: string): PortalRedirectState {
+    const now = new Date();
+    const expiresAt = new Date(now.getTime() + REDIRECT_STATE_TTL_SECONDS * 1000);
+    return {
+      state: randomBytes(24).toString('base64url'),
+      returnTo,
+      createdAt: now.toISOString(),
+      expiresAt: expiresAt.toISOString(),
+    };
+  }
+
+  /**
+   * Persists a redirect-state record and returns it to the caller.
+   *
+   * @param returnTo - The validated internal path to use after the redirect callback.
+   * @returns The persisted redirect-state record.
+   */
+  private async createAndStoreRedirectState(returnTo: string): Promise<PortalRedirectState> {
+    const redirectState = this.createRedirectState(returnTo);
+    await this.sessionStore.saveRedirectState(redirectState);
+    return redirectState;
+  }
+
+  /**
+   * Persists a redirect-state record and redirects the browser to the fixed callback route.
+   *
+   * @param response - The outgoing HTTP response used for the redirect.
+   * @param returnTo - The validated internal path to restore after the callback route resolves.
+   */
+  private async redirectToStoredTarget(response: Response, returnTo: string): Promise<void> {
+    const redirectState = await this.createAndStoreRedirectState(returnTo);
+    response.redirect(302, this.redirectStatePath(redirectState.state));
+  }
+
+  /**
+   * Builds the fixed internal callback path for a redirect-state token.
+   *
+   * @param state - The server-generated redirect-state token.
+   * @returns The callback path that will resolve the stored redirect target.
+   */
+  private redirectStatePath(state: string): string {
+    const params = new URLSearchParams({ state });
+    return `/api/auth/redirect?${params.toString()}`;
   }
 
   /**
@@ -516,25 +604,49 @@ export class AuthSessionService {
    * @returns A safe relative URL path, defaulting to `'/'`.
    */
   private normalizeReturnTo(value: string | undefined): string {
-    if (!value) {
+    if (!value || !value.startsWith('/') || value.startsWith('//')) {
       return '/';
     }
 
     try {
       const parsed = new URL(value, 'http://localhost');
-      const relative = `${parsed.pathname}${parsed.search}${parsed.hash}`;
-      if (relative.startsWith('/') && !relative.startsWith('//')) {
-        return relative;
+      if (parsed.origin !== 'http://localhost') {
+        return '/';
       }
+
+      const pathname = this.normalizeReturnPath(parsed.pathname);
+      if (!this.isAllowedReturnPath(pathname)) {
+        return '/';
+      }
+
+      return `${pathname}${parsed.search}${parsed.hash}`;
     } catch {
-      // Fall back to the raw relative path handling below.
+      return '/';
+    }
+  }
+
+  /**
+   * Normalizes a return-path pathname by trimming trailing slashes from non-root routes.
+   *
+   * @param pathname - The parsed pathname component of the target URL.
+   * @returns The canonical pathname used for route allowlist matching.
+   */
+  private normalizeReturnPath(pathname: string): string {
+    if (pathname === '/') {
+      return pathname;
     }
 
-    if (value.startsWith('/') && !value.startsWith('//')) {
-      return value;
-    }
+    return pathname.replace(/\/+$/, '');
+  }
 
-    return '/';
+  /**
+   * Returns `true` when the pathname matches one of the known SPA routes.
+   *
+   * @param pathname - The canonical pathname to validate.
+   * @returns `true` when the pathname is safe to use as a post-auth return target.
+   */
+  private isAllowedReturnPath(pathname: string): boolean {
+    return RETURN_TO_ROUTE_PATTERNS.some((pattern) => pattern.test(pathname));
   }
 
   /**

--- a/tenant-onboarding-portal/backend/src/storage/session-store.service.ts
+++ b/tenant-onboarding-portal/backend/src/storage/session-store.service.ts
@@ -3,10 +3,11 @@ import { TableClient, TableEntity } from '@azure/data-tables';
 import { DefaultAzureCredential } from '@azure/identity';
 
 import { getSettings } from '../config/settings';
-import type { PortalLoginState, PortalSessionRecord } from '../types';
+import type { PortalLoginState, PortalRedirectState, PortalSessionRecord } from '../types';
 
 const SESSIONS_TABLE = 'TenantPortalSessions';
 const LOGIN_PARTITION = 'login';
+const REDIRECT_PARTITION = 'redirect';
 const SESSION_PARTITION = 'session';
 
 type MemorySessionEntities = Record<string, Record<string, unknown>>;
@@ -102,6 +103,42 @@ export class SessionStoreService {
   }
 
   /**
+   * Persists a short-lived redirect-state record for internal post-auth redirects.
+   *
+   * @param state - The redirect-state object containing the validated target path.
+   */
+  async saveRedirectState(state: PortalRedirectState): Promise<void> {
+    await this.upsertEntity(REDIRECT_PARTITION, state.state, {
+      ReturnTo: state.returnTo,
+      CreatedAt: state.createdAt,
+      ExpiresAt: state.expiresAt,
+    });
+  }
+
+  /**
+   * Retrieves and atomically deletes the redirect-state record for the given state token.
+   *
+   * Returns `null` if the state is not found or has already expired.
+   *
+   * @param state - The redirect state token received from the internal callback route.
+   * @returns The matching {@link PortalRedirectState}, or `null` if absent or expired.
+   */
+  async consumeRedirectState(state: string): Promise<PortalRedirectState | null> {
+    const entity = await this.getEntity(REDIRECT_PARTITION, state);
+    await this.deleteEntity(REDIRECT_PARTITION, state);
+    if (!entity) {
+      return null;
+    }
+
+    const redirectState = this.deserializeRedirectState(state, entity);
+    if (Date.parse(redirectState.expiresAt) <= Date.now()) {
+      return null;
+    }
+
+    return redirectState;
+  }
+
+  /**
    * Persists a session record, creating or replacing any existing record with the same ID.
    *
    * @param session - The session record to save, including user info and token data.
@@ -163,6 +200,25 @@ export class SessionStoreService {
       state,
       codeVerifier: String(entity.CodeVerifier ?? ''),
       redirectUri: String(entity.RedirectUri ?? ''),
+      returnTo: String(entity.ReturnTo ?? '/'),
+      createdAt: String(entity.CreatedAt ?? new Date().toISOString()),
+      expiresAt: String(entity.ExpiresAt ?? new Date(0).toISOString()),
+    };
+  }
+
+  /**
+   * Deserializes a raw storage entity into a {@link PortalRedirectState} object.
+   *
+   * @param state - The redirect-state token used as the row key.
+   * @param entity - The raw key-value entity from the storage backend.
+   * @returns The deserialized redirect state.
+   */
+  private deserializeRedirectState(
+    state: string,
+    entity: Record<string, unknown>,
+  ): PortalRedirectState {
+    return {
+      state,
       returnTo: String(entity.ReturnTo ?? '/'),
       createdAt: String(entity.CreatedAt ?? new Date().toISOString()),
       expiresAt: String(entity.ExpiresAt ?? new Date(0).toISOString()),

--- a/tenant-onboarding-portal/backend/src/types.ts
+++ b/tenant-onboarding-portal/backend/src/types.ts
@@ -55,6 +55,13 @@ export type PortalLoginState = {
   expiresAt: string;
 };
 
+export type PortalRedirectState = {
+  state: string;
+  returnTo: string;
+  createdAt: string;
+  expiresAt: string;
+};
+
 export type PortalSettings = {
   appName: string;
   debug: boolean;

--- a/tenant-onboarding-portal/backend/tests/session-refresh.test.ts
+++ b/tenant-onboarding-portal/backend/tests/session-refresh.test.ts
@@ -2,7 +2,13 @@ import { beforeEach, expect, test, vi } from 'vitest';
 import type { Request, Response } from 'express';
 
 import { AuthSessionService } from '../src/auth/session.service';
+import { resetSettingsCache } from '../src/config/settings';
 import type { OidcTokenSet, PortalSessionRecord, PortalUser } from '../src/types';
+
+type CapturedRedirect = {
+  statusCode: number;
+  location: string;
+};
 
 function createRequest(cookie: string): Request {
   return {
@@ -24,13 +30,17 @@ function createRequest(cookie: string): Request {
   } as unknown as Request;
 }
 
-function createResponse(setCookieHeaders: string[]): Response {
+function createResponse(setCookieHeaders: string[], redirects: CapturedRedirect[] = []): Response {
   return {
     append(name: string, value: string) {
       if (name === 'Set-Cookie') {
         setCookieHeaders.push(value);
       }
 
+      return this;
+    },
+    redirect(statusCode: number, location: string) {
+      redirects.push({ statusCode, location });
       return this;
     },
   } as unknown as Response;
@@ -62,6 +72,7 @@ beforeEach(() => {
     'https://example.invalid/realms/standard/.well-known/openid-configuration';
   process.env.PORTAL_OIDC_CLIENT_ID = 'tenant-onboarding-portal';
   process.env.PORTAL_OIDC_CLIENT_SECRET = 'test-secret';
+  resetSettingsCache();
 });
 
 test('refreshes active oidc sessions every two minutes and rewrites the cookie', async () => {
@@ -158,4 +169,115 @@ test('does not refresh oidc sessions again before the two minute interval', asyn
   } finally {
     vi.useRealTimers();
   }
+});
+
+test('mock login stores the return target behind an internal redirect state', async () => {
+  process.env.PORTAL_AUTH_MODE = 'mock';
+  process.env.PORTAL_OIDC_DISCOVERY_URL = '';
+  resetSettingsCache();
+
+  const redirects: CapturedRedirect[] = [];
+  const sessionStore = {
+    saveSession: vi.fn(),
+    saveRedirectState: vi.fn(),
+  };
+  const tokenValidator = {};
+  const service = new AuthSessionService(sessionStore as any, tokenValidator as any);
+
+  await service.beginLogin(
+    createRequest(''),
+    createResponse([], redirects),
+    '/tenants/example-tenant?tab=details#summary',
+  );
+
+  expect(sessionStore.saveRedirectState).toHaveBeenCalledWith(
+    expect.objectContaining({
+      returnTo: '/tenants/example-tenant?tab=details#summary',
+    }),
+  );
+  expect(redirects).toHaveLength(1);
+  expect(redirects[0]).toMatchObject({ statusCode: 302 });
+
+  const redirectUrl = new URL(redirects[0].location, 'https://portal.example.test');
+  expect(redirectUrl.pathname).toBe('/api/auth/redirect');
+  expect(redirectUrl.searchParams.get('state')).toBeTruthy();
+});
+
+test('mock login normalizes untrusted return targets to root', async () => {
+  process.env.PORTAL_AUTH_MODE = 'mock';
+  process.env.PORTAL_OIDC_DISCOVERY_URL = '';
+  resetSettingsCache();
+
+  const sessionStore = {
+    saveSession: vi.fn(),
+    saveRedirectState: vi.fn(),
+  };
+  const service = new AuthSessionService(sessionStore as any, {} as any);
+
+  await service.beginLogin(createRequest(''), createResponse([]), 'https://evil.example/phish');
+
+  expect(sessionStore.saveRedirectState).toHaveBeenCalledWith(
+    expect.objectContaining({ returnTo: '/' }),
+  );
+});
+
+test('completeRedirect consumes redirect state and restores the stored path', async () => {
+  const redirects: CapturedRedirect[] = [];
+  const sessionStore = {
+    consumeRedirectState: vi.fn().mockResolvedValue({
+      state: 'state-123',
+      returnTo: '/admin/dashboard',
+      createdAt: '2026-03-08T10:00:00.000Z',
+      expiresAt: '2026-03-08T10:10:00.000Z',
+    }),
+  };
+  const service = new AuthSessionService(sessionStore as any, {} as any);
+
+  await service.completeRedirect(createResponse([], redirects), 'state-123');
+
+  expect(sessionStore.consumeRedirectState).toHaveBeenCalledWith('state-123');
+  expect(redirects).toEqual([{ statusCode: 302, location: '/admin/dashboard' }]);
+});
+
+test('oidc logout uses a fixed callback path for post-logout redirection', async () => {
+  process.env.PORTAL_AUTH_MODE = 'oidc';
+  process.env.PORTAL_OIDC_DISCOVERY_URL =
+    'https://example.invalid/realms/standard/.well-known/openid-configuration';
+  resetSettingsCache();
+
+  const redirects: CapturedRedirect[] = [];
+  const sessionStore = {
+    getSession: vi.fn().mockResolvedValue(null),
+    deleteSession: vi.fn(),
+    saveRedirectState: vi.fn(),
+  };
+  const tokenValidator = {
+    publicConfig: vi.fn().mockResolvedValue({
+      endSessionEndpoint: 'https://idp.example.test/logout',
+      clientId: 'tenant-onboarding-portal',
+    }),
+  };
+  const service = new AuthSessionService(sessionStore as any, tokenValidator as any);
+
+  await service.logout(
+    createRequest(''),
+    createResponse([], redirects),
+    '/admin/review/example-tenant/v1',
+  );
+
+  expect(sessionStore.saveRedirectState).toHaveBeenCalledWith(
+    expect.objectContaining({ returnTo: '/admin/review/example-tenant/v1' }),
+  );
+  expect(redirects).toHaveLength(1);
+
+  const logoutUrl = new URL(redirects[0].location);
+  const postLogoutRedirectUri = logoutUrl.searchParams.get('post_logout_redirect_uri');
+  expect(logoutUrl.origin).toBe('https://idp.example.test');
+  expect(postLogoutRedirectUri).toBeTruthy();
+
+  const callbackUrl = new URL(postLogoutRedirectUri!);
+  expect(callbackUrl.origin).toBe('https://portal.example.test');
+  expect(callbackUrl.pathname).toBe('/api/auth/redirect');
+  expect(callbackUrl.searchParams.get('state')).toBeTruthy();
+  expect(postLogoutRedirectUri).not.toContain('/admin/review/example-tenant/v1');
 });


### PR DESCRIPTION


<!-- ai-hub-infra-changes -->
## AI Hub Infra Changes

**Summary:** 2 to add, 17 to change, 0 to destroy (across 4 stack(s))

<details><summary>Show plan details</summary>

```hcl
Terraform will perform the following actions:

  # module.foundry_project["ai-hub-admin"].azapi_resource.rai_policy["gpt-5.1-chat"] will be updated in-place
  ~ resource "azapi_resource" "rai_policy" {
      ~ body                      = {
          ~ properties = {
              ~ contentFilters = [
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Violence" -> "violence"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Violence" -> "violence"
                        # (4 unchanged attributes hidden)
                    },
                ]
                # (2 unchanged attributes hidden)
            }
        }
        id                        = "/subscriptions/****/resourceGroups/ai-services-hub-test/providers/Microsoft.CognitiveServices/accounts/ai-services-hub-test-foundry/raiPolicies/ai-hub-admin-gpt-5-1-chat-filter"
        name                      = "ai-hub-admin-gpt-5-1-chat-filter"
      ~ output                    = {} -> (known after apply)
        # (7 unchanged attributes hidden)
    }

  # module.foundry_project["gcpe-media-monitoring"].azapi_resource.rai_policy["gpt-4.1"] will be updated in-place
  ~ resource "azapi_resource" "rai_policy" {
      ~ body                      = {
          ~ properties = {
              ~ contentFilters = [
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Violence" -> "violence"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Violence" -> "violence"
                        # (4 unchanged attributes hidden)
                    },
                ]
                # (2 unchanged attributes hidden)
            }
        }
        id                        = "/subscriptions/****/resourceGroups/ai-services-hub-test/providers/Microsoft.CognitiveServices/accounts/ai-services-hub-test-foundry/raiPolicies/gcpe-media-monitoring-gpt-4-1-filter"
        name                      = "gcpe-media-monitoring-gpt-4-1-filter"
      ~ output                    = {} -> (known after apply)
        # (7 unchanged attributes hidden)
    }

  # module.foundry_project["gcpe-media-monitoring"].azapi_resource.rai_policy["gpt-4.1-mini"] will be updated in-place
  ~ resource "azapi_resource" "rai_policy" {
      ~ body                      = {
          ~ properties = {
              ~ contentFilters = [
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Violence" -> "violence"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Violence" -> "violence"
                        # (4 unchanged attributes hidden)
                    },
                ]
                # (2 unchanged attributes hidden)
            }
        }
        id                        = "/subscriptions/****/resourceGroups/ai-services-hub-test/providers/Microsoft.CognitiveServices/accounts/ai-services-hub-test-foundry/raiPolicies/gcpe-media-monitoring-gpt-4-1-mini-filter"
        name                      = "gcpe-media-monitoring-gpt-4-1-mini-filter"
      ~ output                    = {} -> (known after apply)
        # (7 unchanged attributes hidden)
    }

  # module.foundry_project["gcpe-media-monitoring"].azapi_resource.rai_policy["gpt-4.1-nano"] will be updated in-place
  ~ resource "azapi_resource" "rai_policy" {
      ~ body                      = {
          ~ properties = {
              ~ contentFilters = [
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Violence" -> "violence"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Violence" -> "violence"
                        # (4 unchanged attributes hidden)
                    },
                ]
                # (2 unchanged attributes hidden)
            }
        }
        id                        = "/subscriptions/****/resourceGroups/ai-services-hub-test/providers/Microsoft.CognitiveServices/accounts/ai-services-hub-test-foundry/raiPolicies/gcpe-media-monitoring-gpt-4-1-nano-filter"
        name                      = "gcpe-media-monitoring-gpt-4-1-nano-filter"
      ~ output                    = {} -> (known after apply)
        # (7 unchanged attributes hidden)
    }

  # module.foundry_project["gcpe-media-monitoring"].azapi_resource.rai_policy["gpt-4o"] will be updated in-place
  ~ resource "azapi_resource" "rai_policy" {
      ~ body                      = {
          ~ properties = {
              ~ contentFilters = [
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Violence" -> "violence"
```

</details>

---
_Updated by CI — plan against `test` environment (run [#329](https://github.com/bcgov/ai-hub-tracking/actions/runs/23829091491)) at 2026-04-01 02:36:23 UTC._
<!-- /ai-hub-infra-changes -->