### PR TITLE
feat: add opensource vLLM deployment pathway with container apps and gpu

### DIFF
--- a/.github/skills/iac-coder/SKILL.md
+++ b/.github/skills/iac-coder/SKILL.md
@@ -55,8 +55,8 @@ Stacks are deployed in dependency order by `scripts/deploy-scaled.sh`. When addi
 |---|---|---|---|
 | 1 | `shared` | Serial | Shared infra: network, CAE, KV, DNS, App Gateway |
 | 2 | `tenant` (× N) | Parallel | Per-tenant Foundry project + KV, runs once per tenant |
-| 3 | `foundry`, `tenant-user-mgmt`, `pii-redaction` | Parallel | Independent services with no cross-stack deps at deploy time |
-| 3b | `apim` | Serial (after Phase 3) | Reads pii-redaction FQDN via remote state — must run after `pii-redaction` |
+| 3 | `foundry`, `tenant-user-mgmt`, `pii-redaction`, `vllm` | Parallel | Independent services with no cross-stack deps at deploy time |
+| 3b | `apim` | Serial (after Phase 3) | Reads pii-redaction + vllm FQDNs via remote state — must run after Phase 3 |
 | 4 | `key-rotation` | Serial (after Phase 3b) | Reads APIM principal ID via remote state — must run after `apim` |
 
 > **Skill maintenance**: When changing the deploy sequence (adding phases, reordering stacks, or adding new serial/parallel constraints), update both `scripts/deploy-scaled.sh` **and** this skill profile.

--- a/.github/skills/network/SKILL.md
+++ b/.github/skills/network/SKILL.md
@@ -32,7 +32,9 @@ Every network module change should deliver:
 - NSG resource + subnet resource in `modules/network/main.tf` (if new subnet type)
 - Outputs in `modules/network/outputs.tf`
 - Shared stack wiring in `stacks/shared/main.tf` + `stacks/shared/outputs.tf`
-- `terraform fmt -recursive` on `modules/network/` and `stacks/shared/`
+- Consumer wiring in downstream stacks that read the new subnet outputs (for example, `infra-ai-hub/stacks/vllm/main.tf` for `vllm_aca_subnet_id`)
+- Documentation updates in `infra-ai-hub/README.md` and `.github/skills/network/references/REFERENCE.md`; when the public contract changes, update `docs/_pages/terraform-reference.html` + `docs/terraform-reference.html`, and when secret/local-run guidance changes update `docs/_pages/workflows.html` + `docs/workflows.html`
+- Repo quality gate from `infra-ai-hub/`: `terraform fmt -check -recursive && tflint --recursive`
 
 ## External Documentation
 - Use [External Docs Research](../external-docs/SKILL.md) as the single source of truth for external documentation workflow and fallback approval requirements.
@@ -40,6 +42,9 @@ Every network module change should deliver:
 ## Documentation Sync
 - If the change adds, removes, renames, or materially reorganizes tracked files or directories, update the root `README.md` `Folder Structure` section in the same change. Do not add gitignored or local-only artifacts to that tree.
 - Review the documentation sync matrix in [../../copilot-instructions.md](../../copilot-instructions.md) and update any area-specific README or docs pages it calls out for the touched subtree.
+- For any `infra-ai-hub/modules/network` contract change, update `infra-ai-hub/README.md` (network allocations + module outputs) and `.github/skills/network/references/REFERENCE.md` in the same change.
+- If the change affects the GPU Container Apps subnet contract (`vllm-aca-subnet`) or its downstream consumer, review `infra-ai-hub/stacks/vllm/README.md`.
+- If the change affects the published Terraform contract or GitHub secret/local-run instructions, update both tracked docs-site source and published pages: `docs/_pages/terraform-reference.html` + `docs/terraform-reference.html` and/or `docs/_pages/workflows.html` + `docs/workflows.html`.
 
 ## Code Locations
 
@@ -52,6 +57,7 @@ Every network module change should deliver:
 | Shared stack wiring | `infra-ai-hub/stacks/shared/main.tf` → `module "network"` | Passes `subnet_allocation` to module |
 | Shared stack outputs | `infra-ai-hub/stacks/shared/outputs.tf` | PE pool pass-through + backward-compat outputs |
 | Per-env config | `infra-ai-hub/params/{env}/shared.tfvars` → `subnet_allocation` | Full CIDRs per subnet per address space |
+| vLLM consumer | `infra-ai-hub/stacks/vllm/main.tf` | Reads `vllm_aca_subnet_id` and primary PE subnet from shared state |
 | Tenant PE selection | `infra-ai-hub/stacks/tenant/locals.tf` | PE subnet resolution with 3-tier precedence |
 | APIM PE selection | `infra-ai-hub/stacks/apim/locals.tf` | Pinned PE subnet resolution with fallback |
 
@@ -79,6 +85,7 @@ There is **no offset computation** — all CIDRs are explicit in tfvars. The mod
 | `apim-subnet` | `Microsoft.Web/serverFarms` | APIM VNet injection |
 | `appgw-subnet` | None (dedicated, no delegation) | Application Gateway |
 | `aca-subnet` | `Microsoft.App/environments` | Container Apps Environment |
+| `vllm-aca-subnet` | `Microsoft.App/environments` | Dedicated GPU vLLM Container Apps Environment |
 
 ### External VNet Peered Projects (`external_peered_projects`)
 
@@ -106,6 +113,7 @@ Priorities are caller-assigned (400–499) so adding/removing a project never sh
 | `privateendpoints-subnet` | `10.x.x.0/27` | 32 IPs |
 | `apim-subnet` | `10.x.x.32/27` | 32 IPs |
 | `aca-subnet` | `10.x.x.64/27` | 32 IPs |
+| `vllm-aca-subnet` | `10.x.x.96/27` | 32 IPs |
 | `appgw-subnet` | Not deployed | App Gateway disabled |
 
 **Test** — 2 address spaces:
@@ -115,6 +123,7 @@ Priorities are caller-assigned (400–499) so adding/removing a project never sh
 | Workload /24 | `apim-subnet` | `10.x.x.0/27` | 32 IPs |
 | Workload /24 | `appgw-subnet` | `10.x.x.32/27` | 32 IPs |
 | Workload /24 | `aca-subnet` | `10.x.x.64/27` | 32 IPs |
+| Workload /24 | `vllm-aca-subnet` | `10.x.x.96/27` | 32 IPs |
 
 **Prod** — 4 address spaces (placeholder CIDRs, not yet deployed):
 | Space | Subnet | CIDR | Notes |
@@ -122,7 +131,10 @@ Priorities are caller-assigned (400–499) so adding/removing a project never sh
 | Space 1 | `privateendpoints-subnet` | TBD /24 | PE pool space 1 |
 | Space 2 | `privateendpoints-subnet-1` | TBD /24 | PE pool space 2 |
 | Space 3 | `privateendpoints-subnet-2` | TBD /24 | PE pool space 3 |
-| Space 4 | `apim-subnet`, `appgw-subnet`, `aca-subnet` | TBD /27s | Workload space |
+| Space 4 | `apim-subnet` | `10.x.x.0/25` | Workload space |
+| Space 4 | `appgw-subnet` | `10.x.x.128/26` | Workload space |
+| Space 4 | `aca-subnet` | `10.x.x.192/27` | Shared Container Apps Environment |
+| Space 4 | `vllm-aca-subnet` | `10.x.x.224/27` | Dedicated GPU vLLM Container Apps Environment |
 
 ## PE Subnet Pool
 
@@ -178,7 +190,8 @@ pe_subnet_key = "privateendpoints-subnet"    # or "privateendpoints-subnet-1", e
 5. **NSG + Subnet** (`modules/network/main.tf`): NSG with `count`, `azapi_resource` with delegation + `depends_on` all preceding subnets
 6. **Outputs** (`modules/network/outputs.tf`): `xxx_subnet_id`, `xxx_subnet_cidr`, `xxx_nsg_id`
 7. **Shared stack** (`stacks/shared/main.tf` + `outputs.tf`): Wire variable + expose output
-8. **Downstream stack**: Reference via `try(data.terraform_remote_state.shared.outputs.xxx_subnet_id, null)`
+8. **Downstream stacks**: Reference via `try(data.terraform_remote_state.shared.outputs.xxx_subnet_id, null)` and update any consuming stacks such as `stacks/vllm`
+9. **Docs**: Update `infra-ai-hub/README.md`, `.github/skills/network/references/REFERENCE.md`, and any affected `docs/_pages/*.html` + published `docs/*.html` pages
 
 ## Validation Gates (Required)
 1. **CIDR validity:** All values in `subnet_allocation` must be valid CIDRs (`can(cidrhost(cidr, 0))`)
@@ -189,7 +202,8 @@ pe_subnet_key = "privateendpoints-subnet"    # or "privateendpoints-subnet-1", e
 6. **depends_on chain:** New subnet depends on ALL preceding subnets
 7. **NSG at creation:** Included in `azapi_resource` body, not a separate association
 8. **Shared stack output:** Subnet ID exposed for cross-stack consumption
-9. **Format:** `terraform fmt -recursive` on `modules/network/` and `stacks/shared/`
+9. **Docs:** Skill/reference docs and any affected public docs are updated alongside the code change
+10. **Quality gate:** `terraform fmt -check -recursive && tflint --recursive` from `infra-ai-hub/`
 
 ## Detailed References
 

--- a/.github/skills/network/references/REFERENCE.md
+++ b/.github/skills/network/references/REFERENCE.md
@@ -38,13 +38,14 @@ pe_enabled    = contains(keys(local.subnet_cidrs), "privateendpoints-subnet")
 apim_enabled  = contains(keys(local.subnet_cidrs), "apim-subnet")
 appgw_enabled = contains(keys(local.subnet_cidrs), "appgw-subnet")
 aca_enabled   = contains(keys(local.subnet_cidrs), "aca-subnet")
+vllm_aca_enabled = contains(keys(local.subnet_cidrs), "vllm-aca-subnet")
 ```
 
 ### Validation Rules (in variables.tf)
 
 1. `subnet_allocation` must contain at least one address space
 2. All values must be valid CIDR notation (tested via `can(cidrhost(cidr, 0))`)
-3. Subnet names must be one of: `privateendpoints-subnet`, `privateendpoints-subnet-<n>` (where `<n>` starts at 1), `apim-subnet`, `appgw-subnet`, `aca-subnet`
+3. Subnet names must be one of: `privateendpoints-subnet`, `privateendpoints-subnet-<n>` (where `<n>` starts at 1), `apim-subnet`, `appgw-subnet`, `aca-subnet`, `vllm-aca-subnet`
 4. At least one `privateendpoints-subnet` must exist
 5. Each subnet name appears in exactly one address space (no duplicates)
 
@@ -91,7 +92,8 @@ Key behaviors:
 ├── 10.x.x.0/27   (privateendpoints-subnet)  27 usable IPs
 ├── 10.x.x.32/27  (apim-subnet)              27 usable IPs
 ├── 10.x.x.64/27  (aca-subnet)               27 usable IPs
-└── 10.x.x.96–255 (unused — reserved for appgw-subnet growth)
+├── 10.x.x.96/27  (vllm-aca-subnet)          27 usable IPs
+└── 10.x.x.128–255 (unused — reserved for appgw-subnet or future growth)
 ```
 
 ### Test — 2 × /24s (Current)
@@ -104,7 +106,8 @@ Key behaviors:
 ├── 10.x.x.0/27   (apim-subnet)              27 usable IPs
 ├── 10.x.x.32/27  (appgw-subnet)             27 usable IPs
 ├── 10.x.x.64/27  (aca-subnet)               27 usable IPs
-└── 10.x.x.96–255 (unused)
+├── 10.x.x.96/27  (vllm-aca-subnet)          27 usable IPs
+└── 10.x.x.128–255 (unused)
 ```
 
 ### Prod — 4 × /24s (Target Contract)
@@ -120,9 +123,10 @@ Key behaviors:
 └── (privateendpoints-subnet-2)  256 IPs
 
 10.x.x.0/24 — Workload space
-├── (apim-subnet)   /27  32 IPs
-├── (appgw-subnet)  /27  32 IPs
-└── (aca-subnet)    /27  32 IPs
+├── 10.x.x.0/25    (apim-subnet)       128 IPs
+├── 10.x.x.128/26  (appgw-subnet)       64 IPs
+├── 10.x.x.192/27  (aca-subnet)         32 IPs
+└── 10.x.x.224/27  (vllm-aca-subnet)    32 IPs
 ```
 
 ---
@@ -201,6 +205,19 @@ HTTP (80) intentionally blocked — no redirect provided.
 | 130 | Outbound | VirtualNetwork (443, PE access) |
 | 200+ | Inbound | Allow from each target VNet address space (dynamic) |
 
+### vLLM ACA Subnet NSG (`{prefix}-vllm-aca-nsg`)
+| Priority | Direction | Purpose |
+|---|---|---|
+| 100 | Outbound | AzureContainerRegistry (443) |
+| 110 | Outbound | AzureMonitor (443) |
+| 120 | Outbound | AzureActiveDirectory (443) |
+| 125 | Outbound | Storage (443, 445) |
+| 130 | Outbound | VirtualNetwork (443, PE access) |
+| 140 | Outbound | Internet (443, Hugging Face / ACR build context) |
+| 200 | Inbound | AzureLoadBalancer (ACA health probes and control-plane, all ports) |
+| 210 | Inbound | PE subnet CIDR (APIM backend calls routed through vLLM PE NIC, TCP 443) — dynamic, only when PE subnet exists |
+| 220 | Inbound | APIM subnet CIDR (direct APIM calls before PE DNS propagation, TCP 443) — dynamic, only when APIM subnet exists |
+
 ---
 
 ## Subnet Resource Pattern Details
@@ -221,6 +238,7 @@ azapi_resource.private_endpoints_subnet
   └── azapi_resource.apim_subnet  (depends_on: [private_endpoints_subnet])
        └── azapi_resource.appgw_subnet  (depends_on: [private_endpoints_subnet, apim_subnet])
             └── azapi_resource.aca_subnet  (depends_on: [private_endpoints_subnet, apim_subnet, appgw_subnet])
+                 └── azapi_resource.vllm_aca_subnet  (depends_on: [private_endpoints_subnet, apim_subnet, appgw_subnet, aca_subnet])
 ```
 
 Every subnet also includes `locks = [data.azurerm_virtual_network.target.id]`.
@@ -231,6 +249,7 @@ Every subnet also includes `locks = [data.azurerm_virtual_network.target.id]`.
 shared stack (creates subnets, exposes PE pool outputs)
   ├── tenant stack   → PE subnet (via resolved_pe_subnet_id per tenant)
   ├── apim stack     → PE subnet (via resolved_apim_pe_subnet_id), APIM subnet
+  ├── vllm stack     → vLLM ACA subnet + primary PE subnet
   ├── foundry stack  → Does not consume PE subnet
   └── key-rotation   → Does not consume PE subnet
 ```
@@ -258,6 +277,7 @@ No other subnet currently requires a route table.
 | CIDR not within parent address space | Plan fails validation | Ensure inner CIDR falls within outer map key |
 | Duplicate subnet name across address spaces | Terraform validation fails | Each name must appear exactly once |
 | Missing `depends_on` in subnet chain | ARM conflict on VNet, intermittent failures | Include ALL preceding subnets in `depends_on` |
+| Updating subnet code but not docs | Operators copy stale `SUBNET_ALLOCATION` JSON or miss new keys | Update `variables.tf`, `infra-ai-hub/README.md`, this reference, and any affected docs-site pages together |
 | Using `azurerm_subnet` instead of `azapi_resource` | Landing Zone policy violation | Always use `azapi_resource` |
 | Forgetting shared stack output | Downstream stack can't access subnet ID | Add output in `stacks/shared/outputs.tf` |
 | Setting delegation on AppGW subnet | App Gateway rejects delegated subnets | AppGW subnet must have NO delegation |

--- a/.gitignore
+++ b/.gitignore
@@ -72,7 +72,9 @@ temp/
 *.db
 *.http
 tfplan
+tfplan-*
 **/*.tfplan
+**/tfplan-*
 **/tfplan/**
 *.csr
 *.bak

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Bootstrap directory for one-time environment setup. Contains the main setup auto
   - **network**: VNet subnets, NSGs, security boundaries
   - **bastion**: Azure Bastion host for secure access (optional via `enable_bastion`)
   - **jumpbox**: Development VM with Azure/Kubernetes CLI tools (optional via `enable_jumpbox`)
+  - **gpu-vllm-aca**: Bootstrap module that deploys a private vLLM-based Gemma 4 endpoint on Azure Container Apps with a GPU consumption profile, mirrored ACR image, persistent Azure Files-backed Hugging Face cache, optional cache-only offline startup, and private endpoint (optional via `enable_gpu_vllm_aca`)
   - **github-runners-aca**: Self-hosted GitHub runners on Container Apps (optional via `github_runners_aca_enabled`)
   - **azure-proxy**: Secure tunnel (chisel) deployment used for proxying (optional via `enable_azure_proxy`)
   - **monitoring**: Log Analytics and Application Insights for observability
@@ -166,11 +167,11 @@ Bootstrap directory for one-time environment setup. Contains the main setup auto
 ### `infra-ai-hub/`
 Multi-tenant AI Services Hub infrastructure. Manages the stack-based Terraform deployment for APIM, AI Foundry, per-tenant resources, networking, WAF, and published model availability.
 
-- **modules/**: Reusable Terraform modules for shared infra, tenant resources, PII redaction, and key rotation
+- **modules/**: Reusable Terraform modules for shared infra, tenant resources, PII redaction, vLLM service, and key rotation
 - **params/**: Environment configs with per-tenant `tenant.tfvars` files plus shared APIM templates and fragments
 - **scripts/**: Deployment helpers, import extraction, DNS wait logic, and Foundry cleanup tooling
-- **stacks/**: Isolated Terraform roots for `shared`, `tenant`, `foundry`, `apim`, `tenant-user-mgmt`, `pii-redaction`, and `key-rotation`
-- **model-deployments.md**: Current tenant model inventory and quota allocation notes
+- **stacks/**: Isolated Terraform roots for `shared`, `tenant`, `foundry`, `apim`, `tenant-user-mgmt`, `pii-redaction`, `vllm`, and `key-rotation`
+- **model-deployments.md**: Current tenant model inventory, quota allocation notes, and vLLM pathway documentation
 
 ### `pii-redaction-service/`
 Python FastAPI service used by APIM for fail-closed PII redaction via Azure AI Language. Contains the app runtime, tests, container packaging, and service-specific documentation.

--- a/docs/_pages/services.html
+++ b/docs/_pages/services.html
@@ -291,6 +291,11 @@
     </div>
 </div>
 
+<div class="card" style="border-left-color: #22c55e; margin: 1rem 0;">
+    <h3 style="margin-top: 0;">Model Caching</h3>
+    <p>Model weights are persisted on a <strong>dedicated Azure Files share</strong> mounted on every container instance. Downloads happen <strong>once</strong> via an init container; subsequent restarts, scale events, and revision updates reuse the cached weights with no network calls (<code>HF_HUB_OFFLINE=1</code>). This applies to both HuggingFace and AzureML Registry model sources.</p>
+</div>
+
 <!-- ============================== -->
 <h2 id="cognitive-services">Cognitive Services</h2>
 <!-- ============================== -->

--- a/docs/_pages/services.html
+++ b/docs/_pages/services.html
@@ -27,6 +27,15 @@
             <p style="font-size: 0.85rem; margin: 0.5rem 0 0; color: var(--text-secondary);">OpenAI baseline plus tenant-specific Cohere and Mistral</p>
         </div>
     </a>
+    <a href="#open-source-models" class="card-link">
+        <div class="card" style="border-left-color: #f59e0b; text-align: center;">
+            <div class="feature-icon" style="margin: 0 auto 0.5rem; background: #fef3c7; color: #92400e;">
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/><polyline points="3.27 6.96 12 12.01 20.73 6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/></svg>
+            </div>
+            <strong>Open-Source Models</strong>
+            <p style="font-size: 0.85rem; margin: 0.5rem 0 0; color: var(--text-secondary);">GPU-backed vLLM models (Gemma, Phi, Qwen)</p>
+        </div>
+    </a>
     <a href="#cognitive-services" class="card-link">
         <div class="card" style="border-left-color: #7c3aed; text-align: center;">
             <div class="feature-icon purple" style="margin: 0 auto 0.5rem;">
@@ -225,6 +234,62 @@
         </tr>
     </tbody>
 </table>
+
+<!-- ============================== -->
+<h2 id="open-source-models">Open-Source Models (vLLM)</h2>
+<!-- ============================== -->
+
+<p>In addition to the managed Foundry pathway, the hub can serve <strong>open-source models</strong> on dedicated GPU Container Apps via <a href="https://docs.vllm.ai/" rel="noopener noreferrer" target="_blank">vLLM</a>. Tenants access these models through the <strong>same base URL and API key</strong> as Foundry models — only the <code>model</code> field in the request body differs.</p>
+
+<div class="card" style="border-left-color: #f59e0b; margin: 1rem 0;">
+    <h3 style="margin-top: 0;">How It Works</h3>
+    <ul>
+        <li><strong>Same endpoint:</strong> <code>{apim_base}/{tenant}/openai/v1/chat/completions</code></li>
+        <li><strong>Model dispatch:</strong> set <code>"model": "google/gemma-4-31B-it"</code> in the request body — APIM routes to the vLLM backend instead of Foundry</li>
+        <li><strong>No SDK changes:</strong> the vLLM backend exposes an OpenAI-compatible API, so the standard OpenAI Python/JS SDK works unchanged</li>
+        <li><strong>Authentication:</strong> same APIM subscription key — no separate credential needed</li>
+    </ul>
+</div>
+
+<h3>Available Open-Source Models</h3>
+
+<table>
+    <thead>
+        <tr><th>Model</th><th>Model ID</th><th>Size</th><th>GPU Profile</th><th>Source</th></tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>Google Gemma 4 31B-IT</td>
+            <td><code>google/gemma-4-31B-it</code></td>
+            <td>31B params</td>
+            <td>NC24-A100</td>
+            <td>HuggingFace / AzureML Registry</td>
+        </tr>
+        <tr>
+            <td>Microsoft Phi-4 (14B)</td>
+            <td><code>microsoft/phi-4</code></td>
+            <td>14B params</td>
+            <td>NC24-A100</td>
+            <td>HuggingFace / AzureML Registry</td>
+        </tr>
+        <tr>
+            <td>Qwen3 32B AWQ</td>
+            <td><code>Qwen/Qwen3-32B-AWQ</code></td>
+            <td>32B params (4-bit)</td>
+            <td>NC24-A100</td>
+            <td>HuggingFace</td>
+        </tr>
+    </tbody>
+</table>
+
+<div class="alert alert-warning" style="margin-top: 1rem;">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+    </div>
+    <div>
+        <strong>Cold-start warning:</strong> GPU models with <code>min_replicas = 0</code> (scale-to-zero) may take 5–10 minutes to start on first request while model weights load into GPU memory. Tenants for whom latency is critical can request a <code>min_replicas = 1</code> override.
+    </div>
+</div>
 
 <!-- ============================== -->
 <h2 id="cognitive-services">Cognitive Services</h2>

--- a/docs/_pages/terraform-reference.html
+++ b/docs/_pages/terraform-reference.html
@@ -4227,12 +4227,13 @@
 <li><code>aca_proxy.py</code> — Reverse proxy sidecar for Gemma 4 SSE compatibility</li>
 </ul>
 </details>
-<p>Provisions a dedicated GPU Container App Environment, ACR (with image mirroring and optional Gemma 4 / AzureML-init builds), Azure Files storage for model caching, a private endpoint for APIM connectivity, and the GPU Container App itself. Supports two model sources: HuggingFace (default) and AzureML Registry (init-container download with managed identity).</p>
+<p>Provisions a dedicated GPU Container App Environment, ACR (with image mirroring and optional Gemma 4 / AzureML-init builds), Azure Files storage for model caching, a private endpoint for APIM connectivity, and the GPU Container App itself. Supports two model sources: HuggingFace (default) and AzureML Registry (init-container download with managed identity). By default, <code>offline_mode = true</code> pre-downloads models via an init container and runs the main container with <code>HF_HUB_OFFLINE=1</code>, guaranteeing zero re-downloads on restart.</p>
 <h4>Key Variables</h4>
 <table>
 <tr><th>Name</th><th>Type</th><th>Default</th><th>Description</th></tr>
 <tr><td><code>model_id</code></td><td><code>string</code></td><td><code>google/gemma-4-31B-it</code></td><td>Model identifier exposed via the OpenAI-compatible API. This is what tenants pass as the <code>model</code> field.</td></tr>
 <tr><td><code>model_source</code></td><td><code>string</code></td><td><code>huggingface</code></td><td>Where to source model weights: <code>huggingface</code> (pull from HF Hub) or <code>azureml_registry</code> (staged via init container).</td></tr>
+<tr><td><code>offline_mode</code></td><td><code>bool</code></td><td><code>true</code></td><td>When true, an init container pre-downloads the model to Azure Files and the main container runs fully offline. When false, vLLM downloads inline during startup.</td></tr>
 <tr><td><code>azureml_registry</code></td><td><code>object</code></td><td><code>null</code></td><td>AzureML registry configuration. Required when <code>model_source = "azureml_registry"</code>. Includes registry_name, model_name, model_version, registry_resource_id.</td></tr>
 <tr><td><code>image</code></td><td><code>string</code></td><td><code>vllm/vllm-openai:latest</code></td><td>vLLM container image (mirrored into the module's ACR).</td></tr>
 <tr><td><code>workload_profile_type</code></td><td><code>string</code></td><td><code>Consumption-GPU-NC24-A100</code></td><td>GPU workload profile for the Container App Environment.</td></tr>

--- a/docs/_pages/terraform-reference.html
+++ b/docs/_pages/terraform-reference.html
@@ -1878,6 +1878,68 @@
 </tr>
 </table>
 </div>
+<h3 id="stack-pii-redaction">pii-redaction</h3>
+<div class="card" style="border-left-color: #0078d4;">
+<p><strong>Location:</strong> <code>infra-ai-hub/stacks/pii-redaction/</code></p>
+<details>
+<summary style="cursor: pointer; color: var(--bc-blue-light);">Files (6)</summary>
+<ul style="margin-top: 0.5rem;">
+<li><code>backend.tf</code></li>
+<li><code>locals.tf</code></li>
+<li><code>main.tf</code></li>
+<li><code>outputs.tf</code></li>
+<li><code>providers.tf</code></li>
+<li><code>variables.tf</code></li>
+</ul>
+</details>
+<h4>Variables</h4>
+<table>
+<tr><th>Name</th><th>Type</th><th>Default</th><th>Description</th></tr>
+<tr><td><code>app_env</code></td><td><code>string</code></td><td><code>required</code></td><td>Application environment (dev, test, prod)</td></tr>
+<tr><td><code>app_name</code></td><td><code>string</code></td><td><code>required</code></td><td>Application name prefix for resource naming</td></tr>
+<tr><td><code>location</code></td><td><code>string</code></td><td><code>canadacentral</code></td><td>Azure region for resources</td></tr>
+<tr><td><code>shared_config</code></td><td><code>any</code></td><td><code>required</code></td><td>Shared configuration passed from shared stack</td></tr>
+</table>
+<h4>Outputs</h4>
+<table>
+<tr><th>Name</th><th>Description</th></tr>
+<tr><td><code>pii_redaction_service</code></td><td>PII redaction service Container App FQDN, endpoint, and name</td></tr>
+</table>
+</div>
+<h3 id="stack-vllm">vllm</h3>
+<div class="card" style="border-left-color: #0078d4;">
+<p><strong>Location:</strong> <code>infra-ai-hub/stacks/vllm/</code></p>
+<details>
+<summary style="cursor: pointer; color: var(--bc-blue-light);">Files (7)</summary>
+<ul style="margin-top: 0.5rem;">
+<li><code>backend.tf</code></li>
+<li><code>locals.tf</code></li>
+<li><code>main.tf</code></li>
+<li><code>outputs.tf</code></li>
+<li><code>providers.tf</code></li>
+<li><code>README.md</code></li>
+<li><code>variables.tf</code></li>
+</ul>
+</details>
+<p>Deploys GPU-backed vLLM Container Apps for serving open-source models. Reads the <code>vllm_aca_subnet_id</code> from shared remote state and provisions a dedicated GPU Container App Environment with an A100 workload profile. The APIM stack reads vLLM outputs via remote state to wire model-based routing.</p>
+<h4>Variables</h4>
+<table>
+<tr><th>Name</th><th>Type</th><th>Default</th><th>Description</th></tr>
+<tr><td><code>app_env</code></td><td><code>string</code></td><td><code>required</code></td><td>Application environment (dev, test, prod)</td></tr>
+<tr><td><code>app_name</code></td><td><code>string</code></td><td><code>required</code></td><td>Application name prefix for resource naming</td></tr>
+<tr><td><code>location</code></td><td><code>string</code></td><td><code>canadacentral</code></td><td>Azure region for resources</td></tr>
+<tr><td><code>shared_config</code></td><td><code>any</code></td><td><code>required</code></td><td>Shared configuration including vllm block with model_id, model_source, image, GPU config</td></tr>
+<tr><td><code>subscription_id</code></td><td><code>string</code></td><td><code>required</code></td><td>Azure subscription ID</td></tr>
+<tr><td><code>tenant_id</code></td><td><code>string</code></td><td><code>required</code></td><td>Azure tenant ID</td></tr>
+<tr><td><code>client_id</code></td><td><code>string</code></td><td><code>required</code></td><td>Azure client ID for the service principal (OIDC)</td></tr>
+<tr><td><code>use_oidc</code></td><td><code>bool</code></td><td><code>true</code></td><td>Use OIDC for authentication</td></tr>
+</table>
+<h4>Outputs</h4>
+<table>
+<tr><th>Name</th><th>Description</th></tr>
+<tr><td><code>vllm_service</code></td><td>Object containing: container_app_name, container_app_fqdn, openai_endpoint, private_endpoint_name, model_id</td></tr>
+</table>
+</div>
 <h2 id="ai-hub-modules">Modules</h2>
 <p>Reusable modules consumed by the stacks above. Each module wraps Azure Verified Modules (AVM) or native <code>azurerm</code>/<code>azapi</code> resources.</p>
 <h3 id="hub-ai-foundry-hub">ai-foundry-hub</h3>
@@ -3489,13 +3551,13 @@
 <td><code>subnet_allocation</code></td>
 <td><code>map(map(string))</code></td>
 <td><code>required</code></td>
-<td><em>No description</em></td>
+<td>Explicit subnet allocation map. Outer key = address space CIDR, inner key = subnet name, inner value = full subnet CIDR. Supported keys: <code>privateendpoints-subnet</code>, <code>privateendpoints-subnet-&lt;n&gt;</code>, <code>apim-subnet</code>, <code>appgw-subnet</code>, <code>aca-subnet</code>, <code>vllm-aca-subnet</code>.</td>
 </tr>
 <tr>
 <td><code>external_peered_projects</code></td>
 <td><code>map(object({</code></td>
 <td><code>{}</code></td>
-<td><em>No description</em></td>
+<td>Map of external project names to their peered VNet config for direct APIM access (bypasses App Gateway). Key = project name, value = { cidrs = [...], priority = 4xx }.</td>
 </tr>
 </table>
 <h4>Outputs</h4>
@@ -4148,6 +4210,45 @@
 <li><code>null_resource (wait_for_dns_document_intelligence)</code></li>
 <li><code>null_resource (wait_for_dns_speech_services)</code></li>
 </ul>
+</div>
+<h3 id="hub-vllm-service">vllm-service</h3>
+<div class="card" style="border-left-color: #22c55e;">
+<p>GPU vLLM Container App Module</p>
+<p><strong>Location:</strong> <code>infra-ai-hub/modules/vllm-service/</code></p>
+<details>
+<summary style="cursor: pointer; color: var(--bc-blue-light);">Files (7)</summary>
+<ul style="margin-top: 0.5rem;">
+<li><code>main.tf</code></li>
+<li><code>outputs.tf</code></li>
+<li><code>variables.tf</code></li>
+<li><code>versions.tf</code></li>
+<li><code>Dockerfile.gemma4</code> — Gemma 4 compatibility image (Content-Type fix for SSE)</li>
+<li><code>Dockerfile.azureml-init</code> — AzureML registry model-fetch init container</li>
+<li><code>aca_proxy.py</code> — Reverse proxy sidecar for Gemma 4 SSE compatibility</li>
+</ul>
+</details>
+<p>Provisions a dedicated GPU Container App Environment, ACR (with image mirroring and optional Gemma 4 / AzureML-init builds), Azure Files storage for model caching, a private endpoint for APIM connectivity, and the GPU Container App itself. Supports two model sources: HuggingFace (default) and AzureML Registry (init-container download with managed identity).</p>
+<h4>Key Variables</h4>
+<table>
+<tr><th>Name</th><th>Type</th><th>Default</th><th>Description</th></tr>
+<tr><td><code>model_id</code></td><td><code>string</code></td><td><code>google/gemma-4-31B-it</code></td><td>Model identifier exposed via the OpenAI-compatible API. This is what tenants pass as the <code>model</code> field.</td></tr>
+<tr><td><code>model_source</code></td><td><code>string</code></td><td><code>huggingface</code></td><td>Where to source model weights: <code>huggingface</code> (pull from HF Hub) or <code>azureml_registry</code> (staged via init container).</td></tr>
+<tr><td><code>azureml_registry</code></td><td><code>object</code></td><td><code>null</code></td><td>AzureML registry configuration. Required when <code>model_source = "azureml_registry"</code>. Includes registry_name, model_name, model_version, registry_resource_id.</td></tr>
+<tr><td><code>image</code></td><td><code>string</code></td><td><code>vllm/vllm-openai:latest</code></td><td>vLLM container image (mirrored into the module's ACR).</td></tr>
+<tr><td><code>workload_profile_type</code></td><td><code>string</code></td><td><code>Consumption-GPU-NC24-A100</code></td><td>GPU workload profile for the Container App Environment.</td></tr>
+<tr><td><code>quantization</code></td><td><code>string</code></td><td><code>null</code></td><td>vLLM quantization backend (awq, gptq, fp8). Requires a matching pre-quantized model.</td></tr>
+<tr><td><code>infrastructure_subnet_id</code></td><td><code>string</code></td><td><code>required</code></td><td>Subnet ID for the GPU Container App Environment (dedicated <code>/27</code>, delegation: <code>Microsoft.App/environments</code>).</td></tr>
+</table>
+<h4>Outputs</h4>
+<table>
+<tr><th>Name</th><th>Description</th></tr>
+<tr><td><code>private_endpoint_name</code></td><td>Name of the private endpoint connecting the vLLM CAE to the hub VNet</td></tr>
+<tr><td><code>container_app_name</code></td><td>Name of the GPU Container App</td></tr>
+<tr><td><code>container_app_fqdn</code></td><td>FQDN of the Container App (private DNS)</td></tr>
+<tr><td><code>openai_endpoint</code></td><td>Full OpenAI-compatible base URL (<code>https://{fqdn}</code>)</td></tr>
+<tr><td><code>model_id</code></td><td>The model identifier used for APIM routing</td></tr>
+<tr><td><code>azureml_downloader_principal_id</code></td><td>Principal ID of the AzureML downloader identity (null when not using AzureML source)</td></tr>
+</table>
 </div>
 <h3 id="hub-waf-policy">waf-policy</h3>
 <div class="card" style="border-left-color: #22c55e;">

--- a/docs/_pages/workflows.html
+++ b/docs/_pages/workflows.html
@@ -903,6 +903,10 @@ on:
     <div><strong>Format rule:</strong> Paste raw JSON in GitHub secrets (single line is safest). Do not use HCL syntax (for example, <code>subnet_allocation = { ... }</code> or <code>external_peered_projects = { ... }</code>) and do not paste escaped JSON with backslashes.</div>
 </div>
 
+<div class="alert alert-info">
+    <div><strong>Supported subnet keys:</strong> <code>privateendpoints-subnet</code>, <code>privateendpoints-subnet-&lt;n&gt;</code>, <code>apim-subnet</code>, <code>appgw-subnet</code>, <code>aca-subnet</code>, and <code>vllm-aca-subnet</code>. Keep the JSON aligned with the network module contract in <code>infra-ai-hub/modules/network/variables.tf</code>.</div>
+</div>
+
 <h3>How JSON Flows into Terraform</h3>
 
 <ol>

--- a/docs/services.html
+++ b/docs/services.html
@@ -1105,6 +1105,15 @@
             <p style="font-size: 0.85rem; margin: 0.5rem 0 0; color: var(--text-secondary);">OpenAI baseline plus tenant-specific Cohere and Mistral</p>
         </div>
     </a>
+    <a href="#open-source-models" class="card-link">
+        <div class="card" style="border-left-color: #f59e0b; text-align: center;">
+            <div class="feature-icon" style="margin: 0 auto 0.5rem; background: #fef3c7; color: #92400e;">
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/><polyline points="3.27 6.96 12 12.01 20.73 6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/></svg>
+            </div>
+            <strong>Open-Source Models</strong>
+            <p style="font-size: 0.85rem; margin: 0.5rem 0 0; color: var(--text-secondary);">GPU-backed vLLM models (Gemma, Phi, Qwen)</p>
+        </div>
+    </a>
     <a href="#cognitive-services" class="card-link">
         <div class="card" style="border-left-color: #7c3aed; text-align: center;">
             <div class="feature-icon purple" style="margin: 0 auto 0.5rem;">
@@ -1301,6 +1310,60 @@
         </tr>
     </tbody>
 </table>
+
+<h2 id="open-source-models">Open-Source Models (vLLM)</h2>
+
+<p>In addition to the managed Foundry pathway, the hub can serve <strong>open-source models</strong> on dedicated GPU Container Apps via <a href="https://docs.vllm.ai/" rel="noopener noreferrer" target="_blank">vLLM</a>. Tenants access these models through the <strong>same base URL and API key</strong> as Foundry models — only the <code>model</code> field in the request body differs.</p>
+
+<div class="card" style="border-left-color: #f59e0b; margin: 1rem 0;">
+    <h3 id="how-it-works" style="margin-top: 0;">How It Works</h3>
+    <ul>
+        <li><strong>Same endpoint:</strong> <code>{apim_base}/{tenant}/openai/v1/chat/completions</code></li>
+        <li><strong>Model dispatch:</strong> set <code>"model": "google/gemma-4-31B-it"</code> in the request body — APIM routes to the vLLM backend instead of Foundry</li>
+        <li><strong>No SDK changes:</strong> the vLLM backend exposes an OpenAI-compatible API, so the standard OpenAI Python/JS SDK works unchanged</li>
+        <li><strong>Authentication:</strong> same APIM subscription key — no separate credential needed</li>
+    </ul>
+</div>
+
+<h3 id="available-open-source-models">Available Open-Source Models</h3>
+
+<table>
+    <thead>
+        <tr><th>Model</th><th>Model ID</th><th>Size</th><th>GPU Profile</th><th>Source</th></tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>Google Gemma 4 31B-IT</td>
+            <td><code>google/gemma-4-31B-it</code></td>
+            <td>31B params</td>
+            <td>NC24-A100</td>
+            <td>HuggingFace / AzureML Registry</td>
+        </tr>
+        <tr>
+            <td>Microsoft Phi-4 (14B)</td>
+            <td><code>microsoft/phi-4</code></td>
+            <td>14B params</td>
+            <td>NC24-A100</td>
+            <td>HuggingFace / AzureML Registry</td>
+        </tr>
+        <tr>
+            <td>Qwen3 32B AWQ</td>
+            <td><code>Qwen/Qwen3-32B-AWQ</code></td>
+            <td>32B params (4-bit)</td>
+            <td>NC24-A100</td>
+            <td>HuggingFace</td>
+        </tr>
+    </tbody>
+</table>
+
+<div class="alert alert-warning" style="margin-top: 1rem;">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+    </div>
+    <div>
+        <strong>Cold-start warning:</strong> GPU models with <code>min_replicas = 0</code> (scale-to-zero) may take 5–10 minutes to start on first request while model weights load into GPU memory. Tenants for whom latency is critical can request a <code>min_replicas = 1</code> override.
+    </div>
+</div>
 
 <h2 id="cognitive-services">Cognitive Services</h2>
 

--- a/docs/services.html
+++ b/docs/services.html
@@ -1365,6 +1365,11 @@
     </div>
 </div>
 
+<div class="card" style="border-left-color: #22c55e; margin: 1rem 0;">
+    <h3 id="model-caching" style="margin-top: 0;">Model Caching</h3>
+    <p>Model weights are persisted on a <strong>dedicated Azure Files share</strong> mounted on every container instance. Downloads happen <strong>once</strong> via an init container; subsequent restarts, scale events, and revision updates reuse the cached weights with no network calls (<code>HF_HUB_OFFLINE=1</code>). This applies to both HuggingFace and AzureML Registry model sources.</p>
+</div>
+
 <h2 id="cognitive-services">Cognitive Services</h2>
 
 <p>Beyond the model providers listed above, each tenant can access the following Azure AI capabilities through the hub.</p>

--- a/docs/terraform-reference.html
+++ b/docs/terraform-reference.html
@@ -2956,6 +2956,68 @@
 </tr>
 </table>
 </div>
+<h3 id="stack-pii-redaction">pii-redaction</h3>
+<div class="card" style="border-left-color: #0078d4;">
+<p><strong>Location:</strong> <code>infra-ai-hub/stacks/pii-redaction/</code></p>
+<details>
+<summary style="cursor: pointer; color: var(--bc-blue-light);">Files (6)</summary>
+<ul style="margin-top: 0.5rem;">
+<li><code>backend.tf</code></li>
+<li><code>locals.tf</code></li>
+<li><code>main.tf</code></li>
+<li><code>outputs.tf</code></li>
+<li><code>providers.tf</code></li>
+<li><code>variables.tf</code></li>
+</ul>
+</details>
+<h4>Variables</h4>
+<table>
+<tr><th>Name</th><th>Type</th><th>Default</th><th>Description</th></tr>
+<tr><td><code>app_env</code></td><td><code>string</code></td><td><code>required</code></td><td>Application environment (dev, test, prod)</td></tr>
+<tr><td><code>app_name</code></td><td><code>string</code></td><td><code>required</code></td><td>Application name prefix for resource naming</td></tr>
+<tr><td><code>location</code></td><td><code>string</code></td><td><code>canadacentral</code></td><td>Azure region for resources</td></tr>
+<tr><td><code>shared_config</code></td><td><code>any</code></td><td><code>required</code></td><td>Shared configuration passed from shared stack</td></tr>
+</table>
+<h4>Outputs</h4>
+<table>
+<tr><th>Name</th><th>Description</th></tr>
+<tr><td><code>pii_redaction_service</code></td><td>PII redaction service Container App FQDN, endpoint, and name</td></tr>
+</table>
+</div>
+<h3 id="stack-vllm">vllm</h3>
+<div class="card" style="border-left-color: #0078d4;">
+<p><strong>Location:</strong> <code>infra-ai-hub/stacks/vllm/</code></p>
+<details>
+<summary style="cursor: pointer; color: var(--bc-blue-light);">Files (7)</summary>
+<ul style="margin-top: 0.5rem;">
+<li><code>backend.tf</code></li>
+<li><code>locals.tf</code></li>
+<li><code>main.tf</code></li>
+<li><code>outputs.tf</code></li>
+<li><code>providers.tf</code></li>
+<li><code>README.md</code></li>
+<li><code>variables.tf</code></li>
+</ul>
+</details>
+<p>Deploys GPU-backed vLLM Container Apps for serving open-source models. Reads the <code>vllm_aca_subnet_id</code> from shared remote state and provisions a dedicated GPU Container App Environment with an A100 workload profile. The APIM stack reads vLLM outputs via remote state to wire model-based routing.</p>
+<h4>Variables</h4>
+<table>
+<tr><th>Name</th><th>Type</th><th>Default</th><th>Description</th></tr>
+<tr><td><code>app_env</code></td><td><code>string</code></td><td><code>required</code></td><td>Application environment (dev, test, prod)</td></tr>
+<tr><td><code>app_name</code></td><td><code>string</code></td><td><code>required</code></td><td>Application name prefix for resource naming</td></tr>
+<tr><td><code>location</code></td><td><code>string</code></td><td><code>canadacentral</code></td><td>Azure region for resources</td></tr>
+<tr><td><code>shared_config</code></td><td><code>any</code></td><td><code>required</code></td><td>Shared configuration including vllm block with model_id, model_source, image, GPU config</td></tr>
+<tr><td><code>subscription_id</code></td><td><code>string</code></td><td><code>required</code></td><td>Azure subscription ID</td></tr>
+<tr><td><code>tenant_id</code></td><td><code>string</code></td><td><code>required</code></td><td>Azure tenant ID</td></tr>
+<tr><td><code>client_id</code></td><td><code>string</code></td><td><code>required</code></td><td>Azure client ID for the service principal (OIDC)</td></tr>
+<tr><td><code>use_oidc</code></td><td><code>bool</code></td><td><code>true</code></td><td>Use OIDC for authentication</td></tr>
+</table>
+<h4>Outputs</h4>
+<table>
+<tr><th>Name</th><th>Description</th></tr>
+<tr><td><code>vllm_service</code></td><td>Object containing: container_app_name, container_app_fqdn, openai_endpoint, private_endpoint_name, model_id</td></tr>
+</table>
+</div>
 <h2 id="ai-hub-modules">Modules</h2>
 <p>Reusable modules consumed by the stacks above. Each module wraps Azure Verified Modules (AVM) or native <code>azurerm</code>/<code>azapi</code> resources.</p>
 <h3 id="hub-ai-foundry-hub">ai-foundry-hub</h3>
@@ -4567,13 +4629,13 @@
 <td><code>subnet_allocation</code></td>
 <td><code>map(map(string))</code></td>
 <td><code>required</code></td>
-<td><em>No description</em></td>
+<td>Explicit subnet allocation map. Outer key = address space CIDR, inner key = subnet name, inner value = full subnet CIDR. Supported keys: <code>privateendpoints-subnet</code>, <code>privateendpoints-subnet-&lt;n&gt;</code>, <code>apim-subnet</code>, <code>appgw-subnet</code>, <code>aca-subnet</code>, <code>vllm-aca-subnet</code>.</td>
 </tr>
 <tr>
 <td><code>external_peered_projects</code></td>
 <td><code>map(object({</code></td>
 <td><code>{}</code></td>
-<td><em>No description</em></td>
+<td>Map of external project names to their peered VNet config for direct APIM access (bypasses App Gateway). Key = project name, value = { cidrs = [...], priority = 4xx }.</td>
 </tr>
 </table>
 <h4>Outputs</h4>
@@ -5226,6 +5288,45 @@
 <li><code>null_resource (wait_for_dns_document_intelligence)</code></li>
 <li><code>null_resource (wait_for_dns_speech_services)</code></li>
 </ul>
+</div>
+<h3 id="hub-vllm-service">vllm-service</h3>
+<div class="card" style="border-left-color: #22c55e;">
+<p>GPU vLLM Container App Module</p>
+<p><strong>Location:</strong> <code>infra-ai-hub/modules/vllm-service/</code></p>
+<details>
+<summary style="cursor: pointer; color: var(--bc-blue-light);">Files (7)</summary>
+<ul style="margin-top: 0.5rem;">
+<li><code>main.tf</code></li>
+<li><code>outputs.tf</code></li>
+<li><code>variables.tf</code></li>
+<li><code>versions.tf</code></li>
+<li><code>Dockerfile.gemma4</code> — Gemma 4 compatibility image (Content-Type fix for SSE)</li>
+<li><code>Dockerfile.azureml-init</code> — AzureML registry model-fetch init container</li>
+<li><code>aca_proxy.py</code> — Reverse proxy sidecar for Gemma 4 SSE compatibility</li>
+</ul>
+</details>
+<p>Provisions a dedicated GPU Container App Environment, ACR (with image mirroring and optional Gemma 4 / AzureML-init builds), Azure Files storage for model caching, a private endpoint for APIM connectivity, and the GPU Container App itself. Supports two model sources: HuggingFace (default) and AzureML Registry (init-container download with managed identity).</p>
+<h4>Key Variables</h4>
+<table>
+<tr><th>Name</th><th>Type</th><th>Default</th><th>Description</th></tr>
+<tr><td><code>model_id</code></td><td><code>string</code></td><td><code>google/gemma-4-31B-it</code></td><td>Model identifier exposed via the OpenAI-compatible API. This is what tenants pass as the <code>model</code> field.</td></tr>
+<tr><td><code>model_source</code></td><td><code>string</code></td><td><code>huggingface</code></td><td>Where to source model weights: <code>huggingface</code> (pull from HF Hub) or <code>azureml_registry</code> (staged via init container).</td></tr>
+<tr><td><code>azureml_registry</code></td><td><code>object</code></td><td><code>null</code></td><td>AzureML registry configuration. Required when <code>model_source = "azureml_registry"</code>. Includes registry_name, model_name, model_version, registry_resource_id.</td></tr>
+<tr><td><code>image</code></td><td><code>string</code></td><td><code>vllm/vllm-openai:latest</code></td><td>vLLM container image (mirrored into the module's ACR).</td></tr>
+<tr><td><code>workload_profile_type</code></td><td><code>string</code></td><td><code>Consumption-GPU-NC24-A100</code></td><td>GPU workload profile for the Container App Environment.</td></tr>
+<tr><td><code>quantization</code></td><td><code>string</code></td><td><code>null</code></td><td>vLLM quantization backend (awq, gptq, fp8). Requires a matching pre-quantized model.</td></tr>
+<tr><td><code>infrastructure_subnet_id</code></td><td><code>string</code></td><td><code>required</code></td><td>Subnet ID for the GPU Container App Environment (dedicated <code>/27</code>, delegation: <code>Microsoft.App/environments</code>).</td></tr>
+</table>
+<h4>Outputs</h4>
+<table>
+<tr><th>Name</th><th>Description</th></tr>
+<tr><td><code>private_endpoint_name</code></td><td>Name of the private endpoint connecting the vLLM CAE to the hub VNet</td></tr>
+<tr><td><code>container_app_name</code></td><td>Name of the GPU Container App</td></tr>
+<tr><td><code>container_app_fqdn</code></td><td>FQDN of the Container App (private DNS)</td></tr>
+<tr><td><code>openai_endpoint</code></td><td>Full OpenAI-compatible base URL (<code>https://{fqdn}</code>)</td></tr>
+<tr><td><code>model_id</code></td><td>The model identifier used for APIM routing</td></tr>
+<tr><td><code>azureml_downloader_principal_id</code></td><td>Principal ID of the AzureML downloader identity (null when not using AzureML source)</td></tr>
+</table>
 </div>
 <h3 id="hub-waf-policy">waf-policy</h3>
 <div class="card" style="border-left-color: #22c55e;">

--- a/docs/terraform-reference.html
+++ b/docs/terraform-reference.html
@@ -5305,12 +5305,13 @@
 <li><code>aca_proxy.py</code> — Reverse proxy sidecar for Gemma 4 SSE compatibility</li>
 </ul>
 </details>
-<p>Provisions a dedicated GPU Container App Environment, ACR (with image mirroring and optional Gemma 4 / AzureML-init builds), Azure Files storage for model caching, a private endpoint for APIM connectivity, and the GPU Container App itself. Supports two model sources: HuggingFace (default) and AzureML Registry (init-container download with managed identity).</p>
+<p>Provisions a dedicated GPU Container App Environment, ACR (with image mirroring and optional Gemma 4 / AzureML-init builds), Azure Files storage for model caching, a private endpoint for APIM connectivity, and the GPU Container App itself. Supports two model sources: HuggingFace (default) and AzureML Registry (init-container download with managed identity). By default, <code>offline_mode = true</code> pre-downloads models via an init container and runs the main container with <code>HF_HUB_OFFLINE=1</code>, guaranteeing zero re-downloads on restart.</p>
 <h4>Key Variables</h4>
 <table>
 <tr><th>Name</th><th>Type</th><th>Default</th><th>Description</th></tr>
 <tr><td><code>model_id</code></td><td><code>string</code></td><td><code>google/gemma-4-31B-it</code></td><td>Model identifier exposed via the OpenAI-compatible API. This is what tenants pass as the <code>model</code> field.</td></tr>
 <tr><td><code>model_source</code></td><td><code>string</code></td><td><code>huggingface</code></td><td>Where to source model weights: <code>huggingface</code> (pull from HF Hub) or <code>azureml_registry</code> (staged via init container).</td></tr>
+<tr><td><code>offline_mode</code></td><td><code>bool</code></td><td><code>true</code></td><td>When true, an init container pre-downloads the model to Azure Files and the main container runs fully offline. When false, vLLM downloads inline during startup.</td></tr>
 <tr><td><code>azureml_registry</code></td><td><code>object</code></td><td><code>null</code></td><td>AzureML registry configuration. Required when <code>model_source = "azureml_registry"</code>. Includes registry_name, model_name, model_version, registry_resource_id.</td></tr>
 <tr><td><code>image</code></td><td><code>string</code></td><td><code>vllm/vllm-openai:latest</code></td><td>vLLM container image (mirrored into the module's ACR).</td></tr>
 <tr><td><code>workload_profile_type</code></td><td><code>string</code></td><td><code>Consumption-GPU-NC24-A100</code></td><td>GPU workload profile for the Container App Environment.</td></tr>

--- a/docs/workflows.html
+++ b/docs/workflows.html
@@ -1981,6 +1981,10 @@ on:
     <div><strong>Format rule:</strong> Paste raw JSON in GitHub secrets (single line is safest). Do not use HCL syntax (for example, <code>subnet_allocation = { ... }</code> or <code>external_peered_projects = { ... }</code>) and do not paste escaped JSON with backslashes.</div>
 </div>
 
+<div class="alert alert-info">
+    <div><strong>Supported subnet keys:</strong> <code>privateendpoints-subnet</code>, <code>privateendpoints-subnet-&lt;n&gt;</code>, <code>apim-subnet</code>, <code>appgw-subnet</code>, <code>aca-subnet</code>, and <code>vllm-aca-subnet</code>. Keep the JSON aligned with the network module contract in <code>infra-ai-hub/modules/network/variables.tf</code>.</div>
+</div>
+
 <h3 id="how-json-flows-into-terraform">How JSON Flows into Terraform</h3>
 
 <ol>

--- a/infra-ai-hub/README.md
+++ b/infra-ai-hub/README.md
@@ -1279,7 +1279,9 @@ infra-ai-hub/
 │   ├── shared/                        # Phase 1: VNet, subnets, AI Foundry Hub, App GW, WAF, KV, ACR, monitoring
 │   ├── tenant/                        # Phase 2: Per-tenant resources (AI Search, CosmosDB, DI, Storage, KV)
 │   ├── foundry/                       # Phase 3: AI Foundry projects per tenant (parallelism=1)
-│   ├── apim/                          # Phase 3: API Management gateway, policies, tenant subscriptions
+│   ├── apim/                          # Phase 3b: API Management gateway, policies, tenant subscriptions
+│   ├── pii-redaction/                 # Phase 3: PII redaction Container App (optional)
+│   ├── vllm/                          # Phase 3: GPU-backed vLLM open-source model service (optional)
 │   └── tenant-user-mgmt/             # Phase 3: Entra ID user/group assignments (requires Graph API)
 │
 ├── modules/
@@ -1291,7 +1293,10 @@ infra-ai-hub/
 │   ├── waf-policy/            # WAF rules
 │   ├── container-registry/    # Shared ACR
 │   ├── container-app-environment/  # ACA
-│   └── app-configuration/     # Feature flags
+│   ├── app-configuration/     # Feature flags
+│   ├── key-rotation-function/ # APIM key rotation Container App Job
+│   ├── pii-redaction/         # PII redaction Container App service
+│   └── vllm-service/          # vLLM GPU Container App (open-source models via OpenAI-compatible API)
 │
 ├── scripts/
 │   ├── deploy-terraform.sh    # Public entrypoint for all Terraform operations
@@ -1334,7 +1339,8 @@ infra-ai-hub/
 ✅ **Deployment Process**: Stack-based engine validated
 - Phase 1: `shared` stack (network, AI Foundry Hub, App GW, WAF, KV, monitoring)
 - Phase 2: `tenant` stacks in parallel (per-tenant fan-out with isolated state)
-- Phase 3: `foundry` + `apim` + `tenant-user-mgmt` in parallel
+- Phase 3: `foundry` + `pii-redaction` + `vllm` + `tenant-user-mgmt` in parallel
+- Phase 3b: `apim` (sequential, after phase 3 — reads pii-redaction and vllm FQDNs via remote state)
 - Auto-recovery: deposed object cleanup, import-on-conflict, transient error retry
 
 ✅ **Resource Import**: Tested and working
@@ -1684,7 +1690,8 @@ BACKEND_STORAGE_ACCOUNT="${BACKEND_STORAGE_ACCOUNT}" \
 Apply order is deterministic:
 1. `shared`
 2. `tenant` (per tenant, parallel)
-3. `foundry` + `apim` + `tenant-user-mgmt` (all in parallel)
+3. `foundry` + `pii-redaction` + `vllm` + `tenant-user-mgmt` (all in parallel)
+4. `apim` (after phase 3 — reads pii-redaction and vllm FQDNs via remote state)
 
 ```mermaid
 flowchart TD
@@ -1699,9 +1706,12 @@ flowchart TD
 
     subgraph P3["3 parallel stacks"]
       F["foundry stack - foundry.tfstate - parallelism 1"]
-      A["apim stack - apim.tfstate"]
+      P["pii-redaction stack - pii-redaction.tfstate"]
+      V["vllm stack - vllm.tfstate"]
       U["tenant-user-mgmt stack - tenant-user-management.tfstate - runs only with Graph User.Read.All"]
     end
+
+    A["4 apim stack - apim.tfstate"]
   end
 
   S --> T1
@@ -1719,6 +1729,9 @@ flowchart TD
   T1 --> U
   T2 --> U
   TN --> U
+
+  P --> A
+  V --> A
 ```
 
 Recommendation: use `apply` as the primary deployment path.
@@ -1726,9 +1739,10 @@ Recommendation: use `apply` as the primary deployment path.
 Dependency details in this flow:
 - `tenant` reads from `shared` (`private_endpoint_subnet_id`, `log_analytics_workspace_id`, `ai_foundry_hub_id`)
 - `foundry` reads from `shared` (`ai_foundry_hub_id`) and all `tenant-*` states
-- `apim` reads from `shared` (network + AI + observability + key vault outputs) and all `tenant-*` states
+- `apim` reads from `shared` (network + AI + observability + key vault outputs), all `tenant-*` states, `pii-redaction`, and `vllm`
 - `tenant-user-mgmt` reads from all `tenant-*` states and is conditionally skipped if Graph permissions are missing
-- Phase 3 stacks (`foundry`, `apim`, `tenant-user-mgmt`) have no cross-dependencies and run concurrently
+- Phase 3 stacks (`foundry`, `pii-redaction`, `vllm`, `tenant-user-mgmt`) have no cross-dependencies and run concurrently
+- `pii-redaction` and `vllm` are optional — APIM degrades gracefully when their remote states are empty
 
 ---
 

--- a/infra-ai-hub/README.md
+++ b/infra-ai-hub/README.md
@@ -168,9 +168,9 @@ flowchart TB
 
 | Environment | Address Spaces | PE Pool | Workload Subnets |
 |---|---|---|---|
-| Dev | 1 × /24 | 1 × /27 | APIM /27 + ACA /27 |
-| Test | 2 × /24 | 1 × /24 (dedicated) | APIM /27 + AppGW /27 + ACA /27 |
-| Prod | 4 × /24 (target) | 3 × /24 PE pool | APIM /27 + AppGW /27 + ACA /27 |
+| Dev | 1 × /24 | 1 × /27 | APIM /27 + ACA /27 + vLLM ACA /27 |
+| Test | 2 × /24 | 1 × /24 (dedicated) | APIM /27 + AppGW /27 + ACA /27 + vLLM ACA /27 |
+| Prod | 4 × /24 (target) | 3 × /24 PE pool | APIM /25 + AppGW /26 + ACA /27 + vLLM ACA /27 |
 
 ### PE Subnet Pool
 
@@ -258,6 +258,7 @@ Creates subnet infrastructure with NSGs for the Landing Zone VNet. Uses `azapi_r
 | `apim_subnet_id` | APIM subnet ID (null if not allocated) |
 | `appgw_subnet_id` | App Gateway subnet ID (null if not allocated) |
 | `aca_subnet_id` | ACA subnet ID (null if not allocated) |
+| `vllm_aca_subnet_id` | GPU vLLM ACA subnet ID (null if not allocated) |
 | `vnet_id` | VNet resource ID |
 
 ---
@@ -1873,4 +1874,3 @@ Each environment has:
 - **Separate Azure resources** - Deployed to environment-specific resource groups
 - **Separate configuration** - Using environment-specific `params/{env}/` files
 - **Separate access controls** - RBAC permissions per environment
-

--- a/infra-ai-hub/model-deployments.md
+++ b/infra-ai-hub/model-deployments.md
@@ -39,6 +39,37 @@ will warn at plan time if they diverge.
 > `https://huggingface.co/Qwen/Qwen3-32B-AWQ`. The tenant `vllm.models[*].model_id` must
 > be set to `Qwen/Qwen3-32B-AWQ` (the AWQ repo), not `Qwen/Qwen3-32B`.
 
+### AzureML Registry Source
+
+The vLLM module supports downloading model weights directly from an **Azure Machine Learning
+registry** instead of Hugging Face Hub. This is the recommended source when the model is
+available in the [Azure AI model catalogue](https://ai.azure.com/explore/models), when you
+need to avoid HF token management, or when serving an internally fine-tuned model.
+
+**Registration steps:**
+
+1. Find the model in the Azure AI catalogue: `az ml model list --registry-name azureml`.
+2. Get the ARM ID of the registry: `az ml registry show --name azureml --query id -o tsv`.
+3. Set `model_source = "azureml_registry"` and populate `azureml_registry` in `shared.tfvars`
+   (see [stacks/vllm/README.md](stacks/vllm/README.md#azureml-registry-source) for the full schema).
+4. No `huggingface_secret_name` needed — the UA identity authenticates with managed identity.
+
+**Format requirement:** the model asset in the registry must be in **HuggingFace snapshot
+format** (must contain `config.json` at the downloaded root). Community registries
+(`azureml`, `HuggingFace`) meet this requirement for all models listed in the catalogue.
+Custom or fine-tuned registrations must include `config.json`.
+
+**Model source comparison:**
+
+| Attribute | `huggingface` (default) | `azureml_registry` |
+|---|---|---|
+| Weight origin | Hugging Face Hub | AzureML registry (community or internal) |
+| Auth | HF token (Key Vault secret) | UA managed identity (automatic RBAC) |
+| Gated models | Yes, with token | Via registry copy (gate bypassed) |
+| Internal models | No | Yes — register first, then deploy |
+| Download path | `/model-cache/huggingface/hub/` | `/model-cache/azureml/{registry}/{model}/{version}/{model}/` |
+| Offline mode | `offline_mode = true` after first cache | Same — marker file prevents re-download |
+
 ## Regional Quota Limits (Canada East)
 
 These are the maximum TPM quotas available per model across the entire subscription.

--- a/infra-ai-hub/model-deployments.md
+++ b/infra-ai-hub/model-deployments.md
@@ -12,7 +12,7 @@ Both pathways use the same APIM base URL (`{apim}/{tenant}/openai/v1`). The `mod
 
 ### vLLM Cold-Start Warning
 
-`min_replicas = 0` (scale-to-zero) is the default for the vllm stack to control GPU cost. Gemma 4 31B cold start is **5–10 minutes**. Tenants with latency SLAs should request `min_replicas = 1` from the platform operator.
+`min_replicas = 0` (scale-to-zero) is the default for the vllm stack to control GPU cost. Gemma 4 31B cold start is **5–10 minutes**. Tenants that need lower first-token latency should request `min_replicas = 1` from the platform operator, but that only keeps one replica warm. It does not add zone redundancy or change the current vLLM deployment topology: the stack still creates a non-zone-redundant Container Apps environment (`modules/vllm-service/main.tf`) and Azure's Container Apps reliability guidance requires at least two replicas in a zone-redundant environment to spread traffic across availability zones. The published Azure Container Apps service-level commitment remains **99.95%**. Sources: [Azure Container Apps SLA](https://azure.microsoft.com/en-us/support/legal/sla/container-apps/v1_0/), [Microsoft Licensing SLA index](https://www.microsoft.com/licensing/docs/view/service-level-agreements-sla-for-online-services?lang=1), and [Reliability in Azure Container Apps](https://learn.microsoft.com/en-us/azure/reliability/reliability-azure-container-apps#requirements).
 
 ## vLLM Model Catalogue
 

--- a/infra-ai-hub/model-deployments.md
+++ b/infra-ai-hub/model-deployments.md
@@ -3,10 +3,41 @@
 > **IMPORTANT:** This file must be updated whenever tenants are added, removed, or their model deployments are modified.
 > See [IaC Coder Skills](../.github/skills/iac-coder/SKILL.md) for the mandatory update rule.
 
-This document tracks the OpenAI model capacity allocated to each tenant across all environments.
-Capacity values for **GlobalStandard** deployments are in **thousands of Tokens Per Minute (TPM)**.
-Provisioned deployments use **PTU** instead, and their effective input TPM depends on the model-specific PTU throughput table published by Microsoft Learn.
-Percentage values show the share of the regional quota limit consumed by each tenant.
+This document tracks model capacity allocated to each tenant across all environments. The hub supports two AI backend pathways:
+
+- **Azure AI Foundry** — Managed OpenAI and third-party models; capacity in TPM or PTU. Foundry tenants share a regional quota pool.
+- **vLLM (open-source)** — GPU-backed Container App running open-source models (e.g. Gemma 4 31B). Shared GPU infrastructure per environment; no regional quota — capacity is bounded by the GPU workload profile. Tenants opt in via `vllm = { enabled = true, models = [{model_id = "...", tokens_per_minute = N}] }` in `tenant.tfvars`. `tokens_per_minute` is per-model and defaults to the tenant's `rate_limiting.tokens_per_minute` when omitted.
+
+Both pathways use the same APIM base URL (`{apim}/{tenant}/openai/v1`). The `model=` field in the request body selects the backend — no URL change required.
+
+### vLLM Cold-Start Warning
+
+`min_replicas = 0` (scale-to-zero) is the default for the vllm stack to control GPU cost. Gemma 4 31B cold start is **5–10 minutes**. Tenants with latency SLAs should request `min_replicas = 1` from the platform operator.
+
+## vLLM Model Catalogue
+
+The vLLM stack serves **one model per hub environment**. The operator selects the model in
+`params/{env}/shared.tfvars`. When the model changes, all tenant `vllm.models[*].model_id`
+values must be updated to match — the `check "vllm_model_id_matches_deployed_model"` block
+will warn at plan time if they diverge.
+
+> **Memory note:** VRAM budget at `gpu_memory_utilization = 0.9` on an A100 80 GB GPU is
+> **72 GB**. BF16 weight size ≈ `params_B × 2 GB`. The remainder is available for KV cache
+> and CUDA runtime overhead. Larger models (≥ 30 B BF16) leave little KV headroom on a
+> single A100 — use a pre-quantized AWQ variant unless the model fits comfortably.
+
+| Model | HF ID | Licence | BF16 weight | Effective KV budget | `max_model_len` | `quantization` | HF token | Cold start |
+|---|---|---|---|---|---|---|---|---|
+| **Phi-4** | `microsoft/phi-4` | MIT | ~28 GB | ~44 GB | 32 768 | — | No | ~2–3 min |
+| **Qwen3-32B (AWQ)** | `Qwen/Qwen3-32B-AWQ` | Apache 2.0 | ~16 GB (INT4) | ~56 GB | 32 768 | `awq` | No | ~5–8 min |
+| **Gemma 4 31B-it** | `google/gemma-4-31B-it` | Gemma ToU | ~62 GB | ~10 GB ¹ | 32 768 | — | Yes (gated) | ~5–10 min |
+
+> ¹ Tight KV headroom; suitable for low-concurrency workloads. Model requires the `aca_proxy.py`
+> SSE streaming workaround — handled automatically by the module when `model_id` contains `gemma-4`.
+>
+> **Qwen3-32B-AWQ:** Verify the HF repo is available before deploying:
+> `https://huggingface.co/Qwen/Qwen3-32B-AWQ`. The tenant `vllm.models[*].model_id` must
+> be set to `Qwen/Qwen3-32B-AWQ` (the AWQ repo), not `Qwen/Qwen3-32B`.
 
 ## Regional Quota Limits (Canada East)
 

--- a/infra-ai-hub/modules/network/locals.tf
+++ b/infra-ai-hub/modules/network/locals.tf
@@ -19,10 +19,11 @@ locals {
   # ENABLED FLAGS — derived from subnet name presence
   # =============================================================================
 
-  pe_enabled    = contains(keys(local.subnet_cidrs), "privateendpoints-subnet")
-  apim_enabled  = contains(keys(local.subnet_cidrs), "apim-subnet")
-  appgw_enabled = contains(keys(local.subnet_cidrs), "appgw-subnet")
-  aca_enabled   = contains(keys(local.subnet_cidrs), "aca-subnet")
+  pe_enabled       = contains(keys(local.subnet_cidrs), "privateendpoints-subnet")
+  apim_enabled     = contains(keys(local.subnet_cidrs), "apim-subnet")
+  appgw_enabled    = contains(keys(local.subnet_cidrs), "appgw-subnet")
+  aca_enabled      = contains(keys(local.subnet_cidrs), "aca-subnet")
+  vllm_aca_enabled = contains(keys(local.subnet_cidrs), "vllm-aca-subnet")
 
   # =============================================================================
   # PE SUBNET POOL
@@ -60,4 +61,5 @@ locals {
   apim_subnet_cidr             = local.apim_enabled ? local.subnet_cidrs["apim-subnet"] : null
   appgw_subnet_cidr            = local.appgw_enabled ? local.subnet_cidrs["appgw-subnet"] : null
   aca_subnet_cidr              = local.aca_enabled ? local.subnet_cidrs["aca-subnet"] : null
+  vllm_aca_subnet_cidr         = local.vllm_aca_enabled ? local.subnet_cidrs["vllm-aca-subnet"] : null
 }

--- a/infra-ai-hub/modules/network/main.tf
+++ b/infra-ai-hub/modules/network/main.tf
@@ -633,3 +633,164 @@ resource "azapi_resource" "aca_subnet" {
     azapi_resource.appgw_subnet
   ]
 }
+
+# =============================================================================
+# GPU vLLM CONTAINER APPS ENVIRONMENT SUBNET (optional — enabled when "vllm-aca-subnet" exists)
+# Dedicated /27 subnet for the GPU-backed vLLM Container Apps Environment.
+# Must be separate from "aca-subnet" (Consumption-only) because GPU workload
+# profiles require a dedicated CAE which cannot share a Consumption-only subnet.
+# Zone redundancy must be disabled for GPU CAEs — /27 is sufficient.
+#
+# NSG rules mirror the aca-subnet rules plus:
+#   - Outbound: Internet (Docker Hub pull for ACR import, HuggingFace model cache)
+#   - Inbound: APIM subnet (APIM calls vLLM via private endpoint)
+# =============================================================================
+
+# NSG for vLLM ACA subnet
+resource "azurerm_network_security_group" "vllm_aca" {
+  count = local.vllm_aca_enabled ? 1 : 0
+
+  name                = "${var.name_prefix}-vllm-aca-nsg"
+  location            = var.location
+  resource_group_name = var.vnet_resource_group_name
+
+  # --- Outbound: Azure Container Registry (pull vLLM container image) ---
+  security_rule {
+    name                       = "AllowAcrOutbound"
+    priority                   = 100
+    direction                  = "Outbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "443"
+    source_address_prefix      = "VirtualNetwork"
+    destination_address_prefix = "AzureContainerRegistry"
+  }
+
+  # --- Outbound: Azure Monitor (logs, metrics, diagnostics) ---
+  security_rule {
+    name                       = "AllowMonitorOutbound"
+    priority                   = 110
+    direction                  = "Outbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "443"
+    source_address_prefix      = "VirtualNetwork"
+    destination_address_prefix = "AzureMonitor"
+  }
+
+  # --- Outbound: Azure AD (managed identity token acquisition) ---
+  security_rule {
+    name                       = "AllowAadOutbound"
+    priority                   = 120
+    direction                  = "Outbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "443"
+    source_address_prefix      = "VirtualNetwork"
+    destination_address_prefix = "AzureActiveDirectory"
+  }
+
+  # --- Outbound: Azure Storage (model cache Azure Files share) ---
+  security_rule {
+    name                       = "AllowStorageOutbound"
+    priority                   = 125
+    direction                  = "Outbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_ranges    = ["443", "445"]
+    source_address_prefix      = "VirtualNetwork"
+    destination_address_prefix = "Storage"
+  }
+
+  # --- Outbound: VirtualNetwork (PE-backed services) ---
+  security_rule {
+    name                       = "AllowVirtualNetworkOutbound"
+    priority                   = 130
+    direction                  = "Outbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "443"
+    source_address_prefix      = "VirtualNetwork"
+    destination_address_prefix = "VirtualNetwork"
+  }
+
+  # --- Outbound: Internet (HuggingFace model download, ACR build context) ---
+  # Required for initial model weight download and az acr build/import provisioners.
+  security_rule {
+    name                       = "AllowInternetOutbound"
+    priority                   = 140
+    direction                  = "Outbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "443"
+    source_address_prefix      = "VirtualNetwork"
+    destination_address_prefix = "Internet"
+  }
+
+  # --- Inbound: allow each address space in the allocation map → vLLM ACA subnet ---
+  dynamic "security_rule" {
+    for_each = local.address_spaces
+    content {
+      name                       = "AllowVnetInbound-${replace(replace(security_rule.value, ".", "-"), "/", "-")}"
+      priority                   = 200 + index(local.address_spaces, security_rule.value)
+      direction                  = "Inbound"
+      access                     = "Allow"
+      protocol                   = "*"
+      source_address_prefix      = security_rule.value
+      destination_address_prefix = "VirtualNetwork"
+      source_port_range          = "*"
+      destination_port_range     = "*"
+    }
+  }
+
+  tags = var.common_tags
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
+
+# vLLM ACA subnet with delegation — dedicated for GPU Container Apps Environment
+resource "azapi_resource" "vllm_aca_subnet" {
+  count = local.vllm_aca_enabled ? 1 : 0
+
+  type      = "Microsoft.Network/virtualNetworks/subnets@2023-04-01"
+  name      = "vllm-aca-subnet"
+  parent_id = data.azurerm_virtual_network.target.id
+  locks     = [data.azurerm_virtual_network.target.id]
+
+  body = {
+    properties = {
+      addressPrefix = local.vllm_aca_subnet_cidr
+
+      networkSecurityGroup = {
+        id = azurerm_network_security_group.vllm_aca[0].id
+      }
+
+      # GPU Container Apps Environment requires delegation to Microsoft.App/environments
+      delegations = [
+        {
+          name = "Microsoft.App.environments"
+          properties = {
+            serviceName = "Microsoft.App/environments"
+          }
+        }
+      ]
+    }
+  }
+
+  response_export_values = ["*"]
+
+  depends_on = [
+    azapi_resource.pe_subnets,
+    azapi_resource.apim_subnet,
+    azapi_resource.appgw_subnet,
+    azapi_resource.aca_subnet
+  ]
+}

--- a/infra-ai-hub/modules/network/main.tf
+++ b/infra-ai-hub/modules/network/main.tf
@@ -643,7 +643,10 @@ resource "azapi_resource" "aca_subnet" {
 #
 # NSG rules mirror the aca-subnet rules plus:
 #   - Outbound: Internet (Docker Hub pull for ACR import, HuggingFace model cache)
-#   - Inbound: APIM subnet (APIM calls vLLM via private endpoint)
+#   - Inbound:  AzureLoadBalancer (ACA health probes)
+#   - Inbound:  PE subnet CIDR (APIM calls vLLM via its private endpoint NIC)
+#   - Inbound:  APIM subnet CIDR (direct calls before PE DNS propagation)
+# Broad VNet inbound is NOT permitted — only APIM and platform health probes reach vLLM.
 # =============================================================================
 
 # NSG for vLLM ACA subnet
@@ -733,19 +736,50 @@ resource "azurerm_network_security_group" "vllm_aca" {
     destination_address_prefix = "Internet"
   }
 
-  # --- Inbound: allow each address space in the allocation map → vLLM ACA subnet ---
+  # --- Inbound: Azure Load Balancer (ACA health probes and control-plane operations) ---
+  security_rule {
+    name                       = "AllowAzureLoadBalancerInbound"
+    priority                   = 200
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "*"
+    source_port_range          = "*"
+    destination_port_range     = "*"
+    source_address_prefix      = "AzureLoadBalancer"
+    destination_address_prefix = "*"
+  }
+
+  # --- Inbound: PE subnet (APIM backend calls routed through the vLLM private endpoint) ---
+  # APIM resolves the Container App FQDN to the PE NIC IP (in privateendpoints-subnet) via
+  # private DNS, so the source address on the vllm-aca-subnet side is the PE subnet CIDR.
   dynamic "security_rule" {
-    for_each = local.address_spaces
+    for_each = local.pe_enabled ? [local.private_endpoint_subnet_cidr] : []
     content {
-      name                       = "AllowVnetInbound-${replace(replace(security_rule.value, ".", "-"), "/", "-")}"
-      priority                   = 200 + index(local.address_spaces, security_rule.value)
+      name                       = "AllowPeSubnetInbound"
+      priority                   = 210
       direction                  = "Inbound"
       access                     = "Allow"
-      protocol                   = "*"
-      source_address_prefix      = security_rule.value
-      destination_address_prefix = "VirtualNetwork"
+      protocol                   = "Tcp"
       source_port_range          = "*"
-      destination_port_range     = "*"
+      destination_port_range     = "443"
+      source_address_prefix      = security_rule.value
+      destination_address_prefix = "*"
+    }
+  }
+
+  # --- Inbound: APIM subnet (direct APIM calls before PE DNS propagation is complete) ---
+  dynamic "security_rule" {
+    for_each = local.apim_enabled ? [local.apim_subnet_cidr] : []
+    content {
+      name                       = "AllowApimSubnetInbound"
+      priority                   = 220
+      direction                  = "Inbound"
+      access                     = "Allow"
+      protocol                   = "Tcp"
+      source_port_range          = "*"
+      destination_port_range     = "443"
+      source_address_prefix      = security_rule.value
+      destination_address_prefix = "*"
     }
   }
 

--- a/infra-ai-hub/modules/network/outputs.tf
+++ b/infra-ai-hub/modules/network/outputs.tf
@@ -92,6 +92,24 @@ output "aca_nsg_id" {
   value       = local.aca_enabled ? azurerm_network_security_group.aca[0].id : null
 }
 
+# -----------------------------------------------------------------------------
+# GPU vLLM Container Apps Environment Subnet Outputs
+# -----------------------------------------------------------------------------
+output "vllm_aca_subnet_id" {
+  description = "Resource ID of the vLLM ACA subnet (null if not enabled)"
+  value       = local.vllm_aca_enabled ? azapi_resource.vllm_aca_subnet[0].id : null
+}
+
+output "vllm_aca_subnet_cidr" {
+  description = "CIDR of the vLLM ACA subnet (null if not enabled)"
+  value       = local.vllm_aca_subnet_cidr
+}
+
+output "vllm_aca_nsg_id" {
+  description = "Resource ID of the vLLM ACA NSG (null if not enabled)"
+  value       = local.vllm_aca_enabled ? azurerm_network_security_group.vllm_aca[0].id : null
+}
+
 
 # -----------------------------------------------------------------------------
 # VNet Information

--- a/infra-ai-hub/modules/network/variables.tf
+++ b/infra-ai-hub/modules/network/variables.tf
@@ -44,6 +44,7 @@ variable "subnet_allocation" {
     - "apim-subnet"                — APIM VNet injection (delegation: Microsoft.Web/serverFarms)
     - "appgw-subnet"               — Application Gateway (no delegation, dedicated)
     - "aca-subnet"                 — Container Apps Environment (delegation: Microsoft.App/environments)
+    - "vllm-aca-subnet"            — GPU vLLM Container Apps Environment (delegation: Microsoft.App/environments)
 
     Each subnet CIDR must fall within its parent address space.
     Subnets are independent — changing one does not recompute others.
@@ -51,14 +52,14 @@ variable "subnet_allocation" {
     Example (2 address spaces):
       subnet_allocation = {
         "10.x.x.0/24" = { "privateendpoints-subnet" = "10.x.x.0/24" }
-        "10.x.x.0/24"  = { "apim-subnet" = "10.x.x.0/27", "appgw-subnet" = "10.x.x.32/27", "aca-subnet" = "10.x.x.64/27" }
+        "10.x.x.0/24"  = { "apim-subnet" = "10.x.x.0/27", "appgw-subnet" = "10.x.x.32/27", "aca-subnet" = "10.x.x.64/27", "vllm-aca-subnet" = "10.x.x.96/27" }
       }
     Example (4 address spaces):
       subnet_allocation = {
         "10.x.x.0/24" = { "privateendpoints-subnet" = "10.x.x.0/24" }
         "10.x.x.0/24"  = { "privateendpoints-subnet-1" = "10.x.x.0/24" }
         "10.x.x.0/24"  = { "privateendpoints-subnet-2" = "10.x.x.0/24" }
-        "10.x.x.0/24"  = { "apim-subnet" = "10.x.x.0/25", "appgw-subnet" = "10.x.x.128/26", "aca-subnet" = "10.x.x.192/27" }
+        "10.x.x.0/24"  = { "apim-subnet" = "10.x.x.0/25", "appgw-subnet" = "10.x.x.128/26", "aca-subnet" = "10.x.x.192/27", "vllm-aca-subnet" = "10.x.x.224/27" }
       }
     Future Growth:
     - To add more PE subnets, simply add new "privateendpoints-subnet-<n>" entries with unique <n> suffixes.
@@ -84,11 +85,11 @@ variable "subnet_allocation" {
     condition = alltrue(flatten([
       for space_cidr, subnets in var.subnet_allocation : [
         for name, _ in subnets : contains([
-          "privateendpoints-subnet", "apim-subnet", "appgw-subnet", "aca-subnet"
+          "privateendpoints-subnet", "apim-subnet", "appgw-subnet", "aca-subnet", "vllm-aca-subnet"
         ], name) || can(regex("^privateendpoints-subnet-[1-9]\\d*$", name))
       ]
     ]))
-    error_message = "Subnet names must be one of: privateendpoints-subnet, privateendpoints-subnet-<n> (n starts at 1), apim-subnet, appgw-subnet, aca-subnet."
+    error_message = "Subnet names must be one of: privateendpoints-subnet, privateendpoints-subnet-<n> (n starts at 1), apim-subnet, appgw-subnet, aca-subnet, vllm-aca-subnet."
   }
 
   validation {
@@ -170,5 +171,4 @@ variable "external_peered_projects" {
     error_message = "Each project must have a unique priority value."
   }
 }
-
 

--- a/infra-ai-hub/modules/vllm-service/Dockerfile.azureml-init
+++ b/infra-ai-hub/modules/vllm-service/Dockerfile.azureml-init
@@ -1,0 +1,16 @@
+# Azure CLI init container for Azure ML registry model staging.
+# Pre-installs the Azure ML CLI extension to avoid runtime extension install
+# delays and outbound-network dependency brittleness.
+#
+# To update the Azure CLI version: change AZURE_CLI_VERSION, commit, and
+# the null_resource.build_azureml_init_image trigger (filemd5) will force a
+# rebuild on next tf apply.
+ARG AZURE_CLI_VERSION=2.67.0
+FROM mcr.microsoft.com/azure-cli:${AZURE_CLI_VERSION}
+
+RUN az extension add -n ml --yes --only-show-errors
+
+COPY azureml-init.sh /usr/local/bin/azureml-init.sh
+RUN chmod +x /usr/local/bin/azureml-init.sh
+
+CMD ["/usr/local/bin/azureml-init.sh"]

--- a/infra-ai-hub/modules/vllm-service/Dockerfile.gemma4
+++ b/infra-ai-hub/modules/vllm-service/Dockerfile.gemma4
@@ -1,0 +1,6 @@
+ARG VLLM_BASE_IMAGE=vllm/vllm-openai:latest
+FROM ${VLLM_BASE_IMAGE}
+
+COPY aca_proxy.py /opt/aca_proxy.py
+
+RUN python3 -m pip install --no-cache-dir --upgrade "transformers==5.5.3"

--- a/infra-ai-hub/modules/vllm-service/aca_proxy.py
+++ b/infra-ai-hub/modules/vllm-service/aca_proxy.py
@@ -1,0 +1,137 @@
+import asyncio
+import os
+import signal
+import subprocess
+import sys
+
+import httpx
+import uvicorn
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse, Response, StreamingResponse
+from starlette.background import BackgroundTask
+
+
+LISTEN_HOST = os.getenv("VLLM_PROXY_HOST", "0.0.0.0")
+LISTEN_PORT = int(os.getenv("VLLM_PROXY_PORT", "8000"))
+BACKEND_URL = os.getenv("VLLM_BACKEND_URL", "http://127.0.0.1:8001")
+FORWARDED_METHODS = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+UPSTREAM_TIMEOUT = httpx.Timeout(connect=1.0, read=None, write=None, pool=None)
+EXCLUDED_HEADERS = {
+    "connection",
+    "content-length",
+    "content-encoding",
+    "host",
+    "keep-alive",
+    "transfer-encoding",
+}
+
+
+app = FastAPI()
+client = httpx.AsyncClient(base_url=BACKEND_URL, timeout=UPSTREAM_TIMEOUT)
+backend_process = None
+
+
+def backend_exited() -> bool:
+    return backend_process is not None and backend_process.poll() is not None
+
+
+async def backend_ready() -> bool:
+    if backend_exited():
+        return False
+
+    try:
+        response = await client.get("/v1/models")
+    except httpx.RequestError:
+        return False
+
+    return response.status_code < 500
+
+
+async def watch_backend() -> None:
+    loop = asyncio.get_running_loop()
+    exit_code = await loop.run_in_executor(None, backend_process.wait)
+    os._exit(exit_code if exit_code != 0 else 0)
+
+
+@app.on_event("startup")
+async def start_backend() -> None:
+    global backend_process
+
+    backend_command = [sys.executable, "/usr/local/bin/vllm", "serve", *sys.argv[1:]]
+    backend_process = subprocess.Popen(backend_command)
+    asyncio.create_task(watch_backend())
+
+
+@app.on_event("shutdown")
+async def stop_backend() -> None:
+    if backend_process is None or backend_exited():
+        return
+
+    backend_process.send_signal(signal.SIGTERM)
+
+    try:
+        await asyncio.get_running_loop().run_in_executor(None, backend_process.wait, 10)
+    except subprocess.TimeoutExpired:
+        backend_process.kill()
+
+    await client.aclose()
+
+
+@app.get("/healthz")
+async def healthz() -> Response:
+    if backend_exited():
+        return JSONResponse(
+            {"status": "exited", "exit_code": backend_process.returncode},
+            status_code=500,
+        )
+
+    if await backend_ready():
+        return JSONResponse({"status": "ready"})
+
+    return JSONResponse({"status": "warming"}, status_code=503)
+
+
+@app.api_route("/{path:path}", methods=FORWARDED_METHODS)
+async def proxy(path: str, request: Request) -> Response:
+    if backend_exited():
+        return JSONResponse(
+            {"error": "vllm backend exited", "exit_code": backend_process.returncode},
+            status_code=500,
+        )
+
+    request_headers = {
+        key: value
+        for key, value in request.headers.items()
+        if key.lower() not in EXCLUDED_HEADERS
+    }
+
+    upstream_url = httpx.URL(path=f"/{path}", query=request.url.query.encode())
+    request_body = await request.body()
+
+    try:
+        upstream_request = client.build_request(
+            request.method,
+            upstream_url,
+            headers=request_headers,
+            content=request_body,
+        )
+        upstream_response = await client.send(upstream_request, stream=True)
+    except httpx.RequestError:
+        return JSONResponse({"error": "vllm backend warming"}, status_code=503)
+
+    response_headers = {
+        key: value
+        for key, value in upstream_response.headers.items()
+        if key.lower() not in EXCLUDED_HEADERS
+    }
+
+    return StreamingResponse(
+        upstream_response.aiter_raw(),
+        status_code=upstream_response.status_code,
+        headers=response_headers,
+        background=BackgroundTask(upstream_response.aclose),
+    )
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host=LISTEN_HOST, port=LISTEN_PORT, log_level="info")

--- a/infra-ai-hub/modules/vllm-service/azureml-init.sh
+++ b/infra-ai-hub/modules/vllm-service/azureml-init.sh
@@ -52,6 +52,22 @@ if [ ! -f "$DOWNLOADED/config.json" ]; then
   exit 1
 fi
 
+# Validate tokenizer assets — required for offline operation since HF_HUB_OFFLINE=1
+# prevents fallback downloads at vLLM runtime.
+if [ ! -f "$DOWNLOADED/tokenizer_config.json" ]; then
+  echo "ERROR: Downloaded model is missing tokenizer_config.json." >&2
+  echo "Tokenizer assets are required for offline mode. Check the registry model packaging." >&2
+  rm -rf "$TEMP_DIR"
+  exit 1
+fi
+
+if [ ! -f "$DOWNLOADED/tokenizer.json" ] && [ ! -f "$DOWNLOADED/tokenizer.model" ]; then
+  echo "ERROR: Downloaded model has no tokenizer.json or tokenizer.model." >&2
+  echo "At least one tokenizer implementation file is required for offline mode." >&2
+  rm -rf "$TEMP_DIR"
+  exit 1
+fi
+
 touch "$DOWNLOADED/.download-complete"
 mkdir -p "$AZUREML_DOWNLOAD_PARENT"
 mv "$DOWNLOADED" "$AZUREML_MODEL_ROOT"

--- a/infra-ai-hub/modules/vllm-service/azureml-init.sh
+++ b/infra-ai-hub/modules/vllm-service/azureml-init.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# azureml-init.sh — Stage a model from an Azure ML registry to the persistent model cache.
+#
+# Expected environment variables (all required unless noted):
+#   AZUREML_REGISTRY_NAME   : AML registry short name (e.g. "my-ml-registry")
+#   AZUREML_MODEL_NAME      : Model asset name in the registry
+#   AZUREML_MODEL_VERSION   : Model asset version (e.g. "1", "2024-11-01")
+#   AZUREML_DOWNLOAD_PARENT : Parent directory on /model-cache where az ml model download
+#                             will create the {model_name}/ subfolder
+#   AZUREML_MODEL_ROOT      : Final model root = AZUREML_DOWNLOAD_PARENT/AZUREML_MODEL_NAME
+#   AZUREML_CLIENT_ID       : Client ID of the user-assigned managed identity for az login
+#   AZUREML_SUBSCRIPTION_ID : (Optional) AML registry subscription; defaults to current
+#
+# az ml model download creates: {download_path}/{model_name}/...
+# This script downloads to a temp dir, validates HF layout (config.json), then moves
+# atomically to AZUREML_MODEL_ROOT and writes a .download-complete marker.
+
+set -euo pipefail
+
+if [ -f "$AZUREML_MODEL_ROOT/.download-complete" ]; then
+  echo "Model already staged at $AZUREML_MODEL_ROOT — skipping download."
+  exit 0
+fi
+
+echo "Logging in with user-assigned managed identity (client ID: $AZUREML_CLIENT_ID)..."
+az login --identity --username "$AZUREML_CLIENT_ID" --only-show-errors >/dev/null
+
+SUBSCRIPTION="${AZUREML_SUBSCRIPTION_ID:-}"
+if [ -n "$SUBSCRIPTION" ]; then
+  echo "Setting subscription to $SUBSCRIPTION..."
+  az account set --subscription "$SUBSCRIPTION" --only-show-errors >/dev/null
+fi
+
+TEMP_DIR="$AZUREML_DOWNLOAD_PARENT/.tmp-$$"
+mkdir -p "$TEMP_DIR"
+
+echo "Downloading $AZUREML_MODEL_NAME (v$AZUREML_MODEL_VERSION) from registry $AZUREML_REGISTRY_NAME..."
+az ml model download \
+  --registry-name "$AZUREML_REGISTRY_NAME" \
+  --name "$AZUREML_MODEL_NAME" \
+  --version "$AZUREML_MODEL_VERSION" \
+  --download-path "$TEMP_DIR" \
+  --only-show-errors
+
+# az ml model download creates {TEMP_DIR}/{model_name}/... — validate and move atomically.
+DOWNLOADED="$TEMP_DIR/$AZUREML_MODEL_NAME"
+
+if [ ! -f "$DOWNLOADED/config.json" ]; then
+  echo "ERROR: Downloaded model is missing config.json." >&2
+  echo "Only HuggingFace-format model assets (with config.json at the root) are supported." >&2
+  rm -rf "$TEMP_DIR"
+  exit 1
+fi
+
+touch "$DOWNLOADED/.download-complete"
+mkdir -p "$AZUREML_DOWNLOAD_PARENT"
+mv "$DOWNLOADED" "$AZUREML_MODEL_ROOT"
+rmdir "$TEMP_DIR" 2>/dev/null || true
+
+echo "Model staged successfully at $AZUREML_MODEL_ROOT"

--- a/infra-ai-hub/modules/vllm-service/main.tf
+++ b/infra-ai-hub/modules/vllm-service/main.tf
@@ -151,9 +151,9 @@ resource "null_resource" "build_gemma4_image" {
 }
 
 # User-assigned managed identity for AzureML registry model downloads.
-# Created before the Container App so the calling stack can assign AzureML Registry User
-# RBAC at plan time, eliminating the RBAC propagation race inherent in system-assigned
-# identities (which only exist after the Container App resource is created).
+# Created before the Container App and role assignment so the identity exists
+# before RBAC is configured, which prevents the propagation race that affects
+# system-assigned identities (those only exist after the Container App is created).
 resource "azurerm_user_assigned_identity" "azureml_downloader" {
   count               = local.use_azureml_registry_source ? 1 : 0
   name                = "${var.app_name}-azureml-downloader"
@@ -164,6 +164,18 @@ resource "azurerm_user_assigned_identity" "azureml_downloader" {
   lifecycle {
     ignore_changes = [tags]
   }
+}
+
+# Grants the user-assigned identity permission to download model assets from
+# the AzureML registry. Placing this role assignment inside the module (rather
+# than the calling stack) allows it to be listed in the Container App depends_on,
+# ensuring RBAC has propagated before the init container starts.
+resource "azurerm_role_assignment" "azureml_registry_user" {
+  count = local.use_azureml_registry_source ? 1 : 0
+
+  scope                = try(var.azureml_registry.registry_resource_id, "")
+  role_definition_name = "AzureML Registry User"
+  principal_id         = azurerm_user_assigned_identity.azureml_downloader[0].principal_id
 }
 
 # Build the AzureML init container image into the module-managed ACR.
@@ -590,6 +602,7 @@ resource "azurerm_container_app" "vllm" {
     null_resource.build_gemma4_image,
     null_resource.import_vllm_image,
     null_resource.build_azureml_init_image,
+    azurerm_role_assignment.azureml_registry_user,
     azurerm_monitor_diagnostic_setting.vllm_environment,
   ]
 

--- a/infra-ai-hub/modules/vllm-service/main.tf
+++ b/infra-ai-hub/modules/vllm-service/main.tf
@@ -41,6 +41,9 @@ locals {
   huggingface_hub_path   = "/model-cache/huggingface/hub"
 
   use_azureml_registry_source = var.model_source == "azureml_registry"
+  use_hf_init_container       = var.model_source == "huggingface" && var.offline_mode
+  # HuggingFace Hub caches model repos in a directory named models--{org}--{repo}.
+  huggingface_model_cache_dir = "${local.huggingface_hub_path}/models--${replace(var.model_id, "/", "--")}"
   # az ml model download creates {download_path}/{model_name}/... so the actual model root
   # is one level deeper than the path passed to --download-path.
   azureml_download_parent = local.use_azureml_registry_source ? "/model-cache/azureml/${var.azureml_registry.registry_name}/${var.azureml_registry.model_name}/${var.azureml_registry.model_version}" : null
@@ -385,7 +388,7 @@ resource "azurerm_container_app" "vllm" {
   }
 
   dynamic "secret" {
-    for_each = var.model_source == "huggingface" && !var.offline_mode && var.huggingface_token != "" ? [var.huggingface_token] : []
+    for_each = var.model_source == "huggingface" && var.huggingface_token != "" ? [var.huggingface_token] : []
 
     content {
       name  = "huggingface-token"
@@ -460,7 +463,7 @@ resource "azurerm_container_app" "vllm" {
       }
 
       dynamic "env" {
-        for_each = var.model_source == "huggingface" && var.offline_mode ? {
+        for_each = var.offline_mode ? {
           HF_HUB_OFFLINE       = "1"
           TRANSFORMERS_OFFLINE = "1"
         } : {}
@@ -574,6 +577,63 @@ resource "azurerm_container_app" "vllm" {
         env {
           name  = "AZUREML_SUBSCRIPTION_ID"
           value = try(var.azureml_registry.subscription_id, "")
+        }
+
+        volume_mounts {
+          name = "model-cache"
+          path = local.model_cache_root
+        }
+      }
+    }
+
+    # HuggingFace model pre-download init container.
+    # When offline_mode = true (default), this init container downloads the model
+    # to the persistent Azure Files cache before vLLM starts. A .download-complete
+    # marker skips re-download on subsequent restarts. The main container then runs
+    # with HF_HUB_OFFLINE=1, guaranteeing zero network calls at runtime.
+    dynamic "init_container" {
+      for_each = local.use_hf_init_container ? [1] : []
+
+      content {
+        name   = "hf-model-download"
+        image  = local.mirrored_image
+        cpu    = 2
+        memory = "4Gi"
+
+        command = ["/bin/sh", "-c", join("\n", [
+          "set -euo pipefail",
+          "MARKER='${local.huggingface_model_cache_dir}/.download-complete'",
+          "if [ -f \"$MARKER\" ]; then",
+          "  echo \"Model ${var.model_id} already cached — skipping download.\"",
+          "  exit 0",
+          "fi",
+          "echo \"Pre-downloading ${var.model_id} to persistent Azure Files cache...\"",
+          "if command -v huggingface-cli >/dev/null 2>&1; then",
+          "  huggingface-cli download '${var.model_id}' --cache-dir '${local.huggingface_hub_path}'",
+          "else",
+          "  python3 -c \"from huggingface_hub import snapshot_download; snapshot_download('${var.model_id}', cache_dir='${local.huggingface_hub_path}')\"",
+          "fi",
+          "touch \"$MARKER\"",
+          "echo \"Model cached successfully.\"",
+        ])]
+
+        env {
+          name  = "HF_HUB_CACHE"
+          value = local.huggingface_hub_path
+        }
+
+        env {
+          name  = "HF_HOME"
+          value = local.huggingface_home
+        }
+
+        dynamic "env" {
+          for_each = var.huggingface_token != "" ? [1] : []
+
+          content {
+            name        = "HF_TOKEN"
+            secret_name = "huggingface-token"
+          }
         }
 
         volume_mounts {

--- a/infra-ai-hub/modules/vllm-service/main.tf
+++ b/infra-ai-hub/modules/vllm-service/main.tf
@@ -1,0 +1,484 @@
+# -----------------------------------------------------------------------------
+# Private GPU vLLM on Azure Container Apps
+# -----------------------------------------------------------------------------
+
+locals {
+  normalized_app_name            = substr(lower(replace(var.app_name, "-", "")), 0, 11)
+  container_app_environment_name = "${var.app_name}-gpu-vllm-env"
+  container_app_name             = "${var.app_name}-gpu-vllm"
+  infrastructure_rg_name         = substr("ME-${var.resource_group_name}-${local.container_app_environment_name}", 0, 90)
+  container_registry_name        = substr("${local.normalized_app_name}vllm${random_string.resource_suffix.result}", 0, 50)
+  model_cache_storage_name       = substr("${local.normalized_app_name}vllmsa${random_string.resource_suffix.result}", 0, 24)
+  model_cache_share_name         = "vllm-model-cache"
+  environment_storage_name       = "modelcache"
+  image_has_registry_host        = length(regexall("^[^/]+\\.[^/]+/.+$", var.image)) > 0
+  use_gemma4_compat_image        = length(regexall("(^|/)gemma-4", var.model_id)) > 0
+  source_image                   = local.image_has_registry_host ? var.image : "docker.io/${var.image}"
+  repository_and_tag             = local.image_has_registry_host ? join("/", slice(split("/", var.image), 1, length(split("/", var.image)))) : var.image
+  gemma4_repository_and_tag      = "vllm/vllm-openai:gemma4-compatible"
+  effective_repository_and_tag   = local.use_gemma4_compat_image ? local.gemma4_repository_and_tag : local.repository_and_tag
+  mirrored_image                 = "${azurerm_container_registry.vllm.login_server}/${local.effective_repository_and_tag}"
+  module_dir                     = replace(path.module, "\\", "/")
+  compat_image_hash              = local.use_gemma4_compat_image ? md5(join(":", [filemd5("${path.module}/Dockerfile.gemma4"), filemd5("${path.module}/aca_proxy.py")])) : null
+
+  workload_profile_resources = {
+    "Consumption-GPU-NC24-A100" = {
+      cpu    = 24
+      memory = "220Gi"
+    }
+    "Consumption-GPU-NC8as-T4" = {
+      cpu    = 8
+      memory = "56Gi"
+    }
+  }
+
+  vllm_service_port      = 8000
+  vllm_backend_port      = local.use_gemma4_compat_image ? 8001 : local.vllm_service_port
+  vllm_backend_host      = local.use_gemma4_compat_image ? "127.0.0.1" : "0.0.0.0"
+  vllm_container_command = local.use_gemma4_compat_image ? ["python3", "/opt/aca_proxy.py"] : null
+  model_cache_root       = "/model-cache"
+  huggingface_home       = "/model-cache/huggingface"
+  huggingface_hub_path   = "/model-cache/huggingface/hub"
+}
+
+resource "random_string" "resource_suffix" {
+  length  = 5
+  lower   = true
+  upper   = false
+  numeric = true
+  special = false
+
+  keepers = {
+    app_name            = var.app_name
+    resource_group_name = var.resource_group_name
+  }
+}
+
+resource "azurerm_container_registry" "vllm" {
+  name                          = local.container_registry_name
+  resource_group_name           = var.resource_group_name
+  location                      = var.location
+  sku                           = var.registry_sku
+  admin_enabled                 = true # Required for az acr build/import provisioners. Assess against hub Azure Policy — MI-based image pull requires removing this.
+  public_network_access_enabled = true # Required for az acr build context push and import from Docker Hub. Private ACR requires a self-hosted build agent with VNet access.
+  tags                          = var.common_tags
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
+
+resource "null_resource" "enable_acr_arm_authentication" {
+  triggers = {
+    registry_name = azurerm_container_registry.vllm.name
+  }
+
+  provisioner "local-exec" {
+    interpreter = ["bash", "-c"]
+    command = join("\n", [
+      "set -euo pipefail",
+      "",
+      "status=$(az acr config authentication-as-arm show --registry ${self.triggers.registry_name} --query status --output tsv --only-show-errors 2>/dev/null || echo disabled)",
+      "",
+      "if [ \"$status\" != \"enabled\" ]; then",
+      "  az acr config authentication-as-arm update --registry ${self.triggers.registry_name} --status enabled --only-show-errors >/dev/null",
+      "fi",
+    ])
+  }
+
+  depends_on = [azurerm_container_registry.vllm]
+}
+
+resource "null_resource" "import_vllm_image" {
+  count = local.use_gemma4_compat_image ? 0 : 1
+
+  triggers = {
+    registry_name = azurerm_container_registry.vllm.name
+    source_image  = local.source_image
+    target_image  = local.repository_and_tag
+  }
+
+  provisioner "local-exec" {
+    interpreter = ["bash", "-c"]
+    command = join("\n", [
+      "set -euo pipefail",
+      "",
+      "if az acr repository show --name ${self.triggers.registry_name} --image ${self.triggers.target_image} --only-show-errors >/dev/null 2>&1; then",
+      "  exit 0",
+      "fi",
+      "",
+      "az acr import --name ${self.triggers.registry_name} --source ${self.triggers.source_image} --image ${self.triggers.target_image} --force --only-show-errors >/dev/null",
+    ])
+  }
+
+  depends_on = [null_resource.enable_acr_arm_authentication]
+}
+
+resource "null_resource" "build_gemma4_image" {
+  count = local.use_gemma4_compat_image ? 1 : 0
+
+  triggers = {
+    registry_name   = azurerm_container_registry.vllm.name
+    source_image    = local.source_image
+    target_image    = local.effective_repository_and_tag
+    dockerfile_hash = filemd5("${path.module}/Dockerfile.gemma4")
+    proxy_hash      = filemd5("${path.module}/aca_proxy.py")
+    context_path    = local.module_dir
+  }
+
+  provisioner "local-exec" {
+    interpreter = ["bash", "-c"]
+    command = join("\n", [
+      "set -euo pipefail",
+      "",
+      "cd '${self.triggers.context_path}'",
+      "az acr build --registry ${self.triggers.registry_name} --image ${self.triggers.target_image} --build-arg VLLM_BASE_IMAGE=${self.triggers.source_image} --file Dockerfile.gemma4 . --no-logs --output none --only-show-errors",
+    ])
+  }
+
+  depends_on = [azurerm_container_registry.vllm]
+}
+
+resource "azurerm_storage_account" "model_cache" {
+  name                            = local.model_cache_storage_name
+  resource_group_name             = var.resource_group_name
+  location                        = var.location
+  account_tier                    = "Standard"
+  account_replication_type        = "LRS"
+  account_kind                    = "StorageV2"
+  public_network_access_enabled   = true
+  https_traffic_only_enabled      = true
+  min_tls_version                 = "TLS1_2"
+  allow_nested_items_to_be_public = false
+  tags                            = var.common_tags
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
+
+resource "azurerm_storage_share" "model_cache" {
+  name               = local.model_cache_share_name
+  storage_account_id = azurerm_storage_account.model_cache.id
+  quota              = var.model_cache_share_quota_gb
+}
+
+resource "azurerm_container_app_environment" "vllm" {
+  name                               = local.container_app_environment_name
+  location                           = var.location
+  resource_group_name                = var.resource_group_name
+  log_analytics_workspace_id         = var.log_analytics_workspace_id
+  logs_destination                   = "log-analytics"
+  infrastructure_subnet_id           = var.infrastructure_subnet_id
+  infrastructure_resource_group_name = local.infrastructure_rg_name
+  internal_load_balancer_enabled     = false
+  public_network_access              = "Disabled"
+  mutual_tls_enabled                 = false
+  zone_redundancy_enabled            = false
+
+  workload_profile {
+    name                  = "Consumption"
+    workload_profile_type = "Consumption"
+  }
+
+  tags = var.common_tags
+
+  lifecycle {
+    ignore_changes = [
+      tags,
+      workload_profile,
+    ]
+  }
+
+  timeouts {
+    create = "60m"
+    update = "60m"
+    delete = "60m"
+  }
+}
+
+resource "azurerm_container_app_environment_storage" "model_cache" {
+  name                         = local.environment_storage_name
+  container_app_environment_id = azurerm_container_app_environment.vllm.id
+  account_name                 = azurerm_storage_account.model_cache.name
+  share_name                   = azurerm_storage_share.model_cache.name
+  access_key                   = azurerm_storage_account.model_cache.primary_access_key
+  access_mode                  = "ReadWrite"
+}
+
+resource "azurerm_private_endpoint" "vllm_environment" {
+  name                = "${local.container_app_environment_name}-pe"
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  subnet_id           = var.private_endpoint_subnet_id
+
+  private_service_connection {
+    name                           = "${local.container_app_environment_name}-psc"
+    private_connection_resource_id = azurerm_container_app_environment.vllm.id
+    subresource_names              = ["managedEnvironments"]
+    is_manual_connection           = false
+  }
+
+  tags = var.common_tags
+
+  lifecycle {
+    ignore_changes = [
+      private_dns_zone_group,
+      tags,
+    ]
+  }
+}
+
+resource "null_resource" "wait_for_dns" {
+  count = var.wait_for_private_endpoint_dns_zone_group ? 1 : 0
+
+  triggers = {
+    private_endpoint_id   = azurerm_private_endpoint.vllm_environment.id
+    resource_group_name   = var.resource_group_name
+    private_endpoint_name = azurerm_private_endpoint.vllm_environment.name
+    timeout               = var.private_endpoint_dns_wait.timeout
+    interval              = var.private_endpoint_dns_wait.poll_interval
+    scripts_dir           = var.scripts_dir
+  }
+
+  provisioner "local-exec" {
+    interpreter = ["bash", "-c"]
+    command = join("\n", [
+      "${self.triggers.scripts_dir}/wait-for-dns-zone.sh --resource-group ${self.triggers.resource_group_name} --private-endpoint-name ${self.triggers.private_endpoint_name} --timeout ${self.triggers.timeout} --interval ${self.triggers.interval}",
+    ])
+  }
+
+  depends_on = [azurerm_private_endpoint.vllm_environment]
+}
+
+resource "null_resource" "gpu_workload_profile" {
+  triggers = {
+    environment_name      = azurerm_container_app_environment.vllm.name
+    resource_group_name   = var.resource_group_name
+    workload_profile_name = var.workload_profile_name
+    workload_profile_type = var.workload_profile_type
+  }
+
+  provisioner "local-exec" {
+    interpreter = ["bash", "-c"]
+    command = join("\n", [
+      "set -euo pipefail",
+      "",
+      "if az containerapp env workload-profile show --resource-group ${self.triggers.resource_group_name} --name ${self.triggers.environment_name} --workload-profile-name ${self.triggers.workload_profile_name} --only-show-errors >/dev/null 2>&1; then",
+      "  exit 0",
+      "fi",
+      "",
+      "az containerapp env workload-profile add --resource-group ${self.triggers.resource_group_name} --name ${self.triggers.environment_name} --workload-profile-name ${self.triggers.workload_profile_name} --workload-profile-type ${self.triggers.workload_profile_type} --only-show-errors >/dev/null",
+    ])
+  }
+
+  depends_on = [azurerm_container_app_environment.vllm]
+}
+
+resource "azurerm_monitor_diagnostic_setting" "vllm_environment" {
+  name                       = "${local.container_app_environment_name}-diagnostics"
+  target_resource_id         = azurerm_container_app_environment.vllm.id
+  log_analytics_workspace_id = var.log_analytics_workspace_id
+
+  enabled_log {
+    category = "ContainerAppConsoleLogs"
+  }
+
+  enabled_log {
+    category = "ContainerAppSystemLogs"
+  }
+
+  enabled_metric {
+    category = "AllMetrics"
+  }
+}
+
+resource "azurerm_container_app" "vllm" {
+  name                         = local.container_app_name
+  resource_group_name          = var.resource_group_name
+  container_app_environment_id = azurerm_container_app_environment.vllm.id
+  revision_mode                = "Single"
+  workload_profile_name        = var.workload_profile_name
+
+  registry {
+    server               = azurerm_container_registry.vllm.login_server
+    username             = azurerm_container_registry.vllm.admin_username
+    password_secret_name = "acr-admin-password"
+  }
+
+  secret {
+    name  = "acr-admin-password"
+    value = azurerm_container_registry.vllm.admin_password
+  }
+
+  dynamic "secret" {
+    for_each = !var.offline_mode && var.huggingface_token != "" ? [var.huggingface_token] : []
+
+    content {
+      name  = "huggingface-token"
+      value = secret.value
+    }
+  }
+
+  ingress {
+    allow_insecure_connections = false
+    external_enabled           = true
+    target_port                = local.vllm_service_port
+    transport                  = "http"
+
+    traffic_weight {
+      latest_revision = true
+      percentage      = 100
+    }
+  }
+
+  template {
+    min_replicas                = var.min_replicas
+    max_replicas                = var.max_replicas
+    cooldown_period_in_seconds  = 1800
+    polling_interval_in_seconds = 15
+
+    http_scale_rule {
+      name                = "http-concurrency"
+      concurrent_requests = "1"
+    }
+
+    container {
+      name    = "vllm"
+      image   = local.mirrored_image
+      cpu     = local.workload_profile_resources[var.workload_profile_type].cpu
+      memory  = local.workload_profile_resources[var.workload_profile_type].memory
+      command = local.vllm_container_command
+
+      args = concat(
+        [
+          var.model_id,
+          "--host",
+          local.vllm_backend_host,
+          "--port",
+          tostring(local.vllm_backend_port),
+          "--max-model-len",
+          tostring(var.max_model_len),
+          "--gpu-memory-utilization",
+          tostring(var.gpu_memory_utilization),
+        ],
+        # Append --quantization only when a backend is explicitly set. Requires a matching
+        # pre-quantized HuggingFace model repo — vLLM does not quantize BF16 weights on the fly.
+        var.quantization != null ? ["--quantization", var.quantization] : []
+      )
+
+      env {
+        name  = "XDG_CACHE_HOME"
+        value = local.model_cache_root
+      }
+
+      env {
+        name  = "HF_HOME"
+        value = local.huggingface_home
+      }
+
+      env {
+        name  = "HF_HUB_CACHE"
+        value = local.huggingface_hub_path
+      }
+
+      dynamic "env" {
+        for_each = var.offline_mode ? {
+          HF_HUB_OFFLINE       = "1"
+          TRANSFORMERS_OFFLINE = "1"
+        } : {}
+
+        content {
+          name  = env.key
+          value = env.value
+        }
+      }
+
+      env {
+        name  = "HF_HUB_DISABLE_SYMLINKS_WARNING"
+        value = "1"
+      }
+
+      env {
+        name  = "VLLM_NO_USAGE_STATS"
+        value = "1"
+      }
+
+      dynamic "env" {
+        for_each = local.compat_image_hash == null ? [] : [local.compat_image_hash]
+
+        content {
+          name  = "GEMMA4_COMPAT_IMAGE_HASH"
+          value = env.value
+        }
+      }
+
+      dynamic "env" {
+        for_each = !var.offline_mode && var.huggingface_token != "" ? [1] : []
+
+        content {
+          name        = "HF_TOKEN"
+          secret_name = "huggingface-token"
+        }
+      }
+
+      volume_mounts {
+        name = "model-cache"
+        path = local.model_cache_root
+      }
+
+      startup_probe {
+        path                    = "/v1/models"
+        port                    = local.vllm_service_port
+        transport               = "HTTP"
+        initial_delay           = 30
+        interval_seconds        = 30
+        failure_count_threshold = 120
+      }
+
+      readiness_probe {
+        path                    = "/v1/models"
+        port                    = local.vllm_service_port
+        transport               = "HTTP"
+        initial_delay           = 15
+        interval_seconds        = 15
+        success_count_threshold = 1
+      }
+
+      liveness_probe {
+        path                    = "/v1/models"
+        port                    = local.vllm_service_port
+        transport               = "HTTP"
+        initial_delay           = 60
+        interval_seconds        = 30
+        failure_count_threshold = 3
+      }
+    }
+
+    volume {
+      name         = "model-cache"
+      storage_name = azurerm_container_app_environment_storage.model_cache.name
+      storage_type = "AzureFile"
+    }
+  }
+
+  tags = var.common_tags
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
+
+  depends_on = [
+    azurerm_container_app_environment_storage.model_cache,
+    null_resource.gpu_workload_profile,
+    null_resource.build_gemma4_image,
+    null_resource.import_vllm_image,
+    azurerm_monitor_diagnostic_setting.vllm_environment,
+  ]
+
+  timeouts {
+    create = "90m"
+    update = "90m"
+    delete = "90m"
+  }
+}

--- a/infra-ai-hub/modules/vllm-service/main.tf
+++ b/infra-ai-hub/modules/vllm-service/main.tf
@@ -39,6 +39,17 @@ locals {
   model_cache_root       = "/model-cache"
   huggingface_home       = "/model-cache/huggingface"
   huggingface_hub_path   = "/model-cache/huggingface/hub"
+
+  use_azureml_registry_source = var.model_source == "azureml_registry"
+  # az ml model download creates {download_path}/{model_name}/... so the actual model root
+  # is one level deeper than the path passed to --download-path.
+  azureml_download_parent = local.use_azureml_registry_source ? "/model-cache/azureml/${var.azureml_registry.registry_name}/${var.azureml_registry.model_name}/${var.azureml_registry.model_version}" : null
+  azureml_model_root      = local.use_azureml_registry_source ? "${local.azureml_download_parent}/${var.azureml_registry.model_name}" : null
+  # For HF source: pass the HF repo ID directly to vllm serve --model.
+  # For AML registry source: pass the local staged path; add --served-model-name var.model_id
+  # in args so the API surface stays consistent with APIM routing.
+  vllm_model_arg     = local.use_azureml_registry_source ? local.azureml_model_root : var.model_id
+  azureml_init_image = local.use_azureml_registry_source ? "${azurerm_container_registry.vllm.login_server}/azureml-init/azure-cli:latest" : null
 }
 
 resource "random_string" "resource_suffix" {
@@ -133,6 +144,48 @@ resource "null_resource" "build_gemma4_image" {
       "",
       "cd '${self.triggers.context_path}'",
       "az acr build --registry ${self.triggers.registry_name} --image ${self.triggers.target_image} --build-arg VLLM_BASE_IMAGE=${self.triggers.source_image} --file Dockerfile.gemma4 . --no-logs --output none --only-show-errors",
+    ])
+  }
+
+  depends_on = [azurerm_container_registry.vllm]
+}
+
+# User-assigned managed identity for AzureML registry model downloads.
+# Created before the Container App so the calling stack can assign AzureML Registry User
+# RBAC at plan time, eliminating the RBAC propagation race inherent in system-assigned
+# identities (which only exist after the Container App resource is created).
+resource "azurerm_user_assigned_identity" "azureml_downloader" {
+  count               = local.use_azureml_registry_source ? 1 : 0
+  name                = "${var.app_name}-azureml-downloader"
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  tags                = var.common_tags
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
+
+# Build the AzureML init container image into the module-managed ACR.
+# Uses Dockerfile.azureml-init (Azure CLI + ml extension pre-baked) to avoid
+# runtime extension installs. Rebuilds automatically when either the Dockerfile
+# or the init script changes (filemd5 trigger).
+resource "null_resource" "build_azureml_init_image" {
+  count = local.use_azureml_registry_source ? 1 : 0
+
+  triggers = {
+    registry_name   = azurerm_container_registry.vllm.name
+    dockerfile_hash = filemd5("${path.module}/Dockerfile.azureml-init")
+    script_hash     = filemd5("${path.module}/azureml-init.sh")
+    context_path    = local.module_dir
+  }
+
+  provisioner "local-exec" {
+    interpreter = ["bash", "-c"]
+    command = join("\n", [
+      "set -euo pipefail",
+      "cd '${self.triggers.context_path}'",
+      "az acr build --registry ${self.triggers.registry_name} --image azureml-init/azure-cli:latest --file Dockerfile.azureml-init . --no-logs --output none --only-show-errors",
     ])
   }
 
@@ -300,6 +353,14 @@ resource "azurerm_container_app" "vllm" {
   revision_mode                = "Single"
   workload_profile_name        = var.workload_profile_name
 
+  dynamic "identity" {
+    for_each = local.use_azureml_registry_source ? [1] : []
+    content {
+      type         = "UserAssigned"
+      identity_ids = [azurerm_user_assigned_identity.azureml_downloader[0].id]
+    }
+  }
+
   registry {
     server               = azurerm_container_registry.vllm.login_server
     username             = azurerm_container_registry.vllm.admin_username
@@ -312,7 +373,7 @@ resource "azurerm_container_app" "vllm" {
   }
 
   dynamic "secret" {
-    for_each = !var.offline_mode && var.huggingface_token != "" ? [var.huggingface_token] : []
+    for_each = var.model_source == "huggingface" && !var.offline_mode && var.huggingface_token != "" ? [var.huggingface_token] : []
 
     content {
       name  = "huggingface-token"
@@ -352,7 +413,7 @@ resource "azurerm_container_app" "vllm" {
 
       args = concat(
         [
-          var.model_id,
+          local.vllm_model_arg,
           "--host",
           local.vllm_backend_host,
           "--port",
@@ -362,8 +423,12 @@ resource "azurerm_container_app" "vllm" {
           "--gpu-memory-utilization",
           tostring(var.gpu_memory_utilization),
         ],
+        # For azureml_registry source, expose the model under its canonical API name.
+        # vLLM's --model arg is the local staged path; --served-model-name keeps the
+        # tenant-facing model ID consistent with APIM routing.
+        local.use_azureml_registry_source ? ["--served-model-name", var.model_id] : [],
         # Append --quantization only when a backend is explicitly set. Requires a matching
-        # pre-quantized HuggingFace model repo — vLLM does not quantize BF16 weights on the fly.
+        # pre-quantized model — vLLM does not quantize weights on the fly.
         var.quantization != null ? ["--quantization", var.quantization] : []
       )
 
@@ -383,7 +448,7 @@ resource "azurerm_container_app" "vllm" {
       }
 
       dynamic "env" {
-        for_each = var.offline_mode ? {
+        for_each = var.model_source == "huggingface" && var.offline_mode ? {
           HF_HUB_OFFLINE       = "1"
           TRANSFORMERS_OFFLINE = "1"
         } : {}
@@ -414,7 +479,7 @@ resource "azurerm_container_app" "vllm" {
       }
 
       dynamic "env" {
-        for_each = !var.offline_mode && var.huggingface_token != "" ? [1] : []
+        for_each = var.model_source == "huggingface" && !var.offline_mode && var.huggingface_token != "" ? [1] : []
 
         content {
           name        = "HF_TOKEN"
@@ -455,6 +520,57 @@ resource "azurerm_container_app" "vllm" {
       }
     }
 
+    dynamic "init_container" {
+      for_each = local.use_azureml_registry_source ? [1] : []
+
+      content {
+        name   = "azureml-model-fetch"
+        image  = local.azureml_init_image
+        cpu    = 2
+        memory = "4Gi"
+
+        env {
+          name  = "AZUREML_REGISTRY_NAME"
+          value = var.azureml_registry.registry_name
+        }
+
+        env {
+          name  = "AZUREML_MODEL_NAME"
+          value = var.azureml_registry.model_name
+        }
+
+        env {
+          name  = "AZUREML_MODEL_VERSION"
+          value = var.azureml_registry.model_version
+        }
+
+        env {
+          name  = "AZUREML_DOWNLOAD_PARENT"
+          value = local.azureml_download_parent
+        }
+
+        env {
+          name  = "AZUREML_MODEL_ROOT"
+          value = local.azureml_model_root
+        }
+
+        env {
+          name  = "AZUREML_CLIENT_ID"
+          value = azurerm_user_assigned_identity.azureml_downloader[0].client_id
+        }
+
+        env {
+          name  = "AZUREML_SUBSCRIPTION_ID"
+          value = try(var.azureml_registry.subscription_id, "")
+        }
+
+        volume_mounts {
+          name = "model-cache"
+          path = local.model_cache_root
+        }
+      }
+    }
+
     volume {
       name         = "model-cache"
       storage_name = azurerm_container_app_environment_storage.model_cache.name
@@ -473,6 +589,7 @@ resource "azurerm_container_app" "vllm" {
     null_resource.gpu_workload_profile,
     null_resource.build_gemma4_image,
     null_resource.import_vllm_image,
+    null_resource.build_azureml_init_image,
     azurerm_monitor_diagnostic_setting.vllm_environment,
   ]
 
@@ -480,5 +597,12 @@ resource "azurerm_container_app" "vllm" {
     create = "90m"
     update = "90m"
     delete = "90m"
+  }
+}
+
+check "azureml_registry_config_required" {
+  assert {
+    condition     = var.model_source != "azureml_registry" || var.azureml_registry != null
+    error_message = "var.azureml_registry must be set when model_source is \"azureml_registry\"."
   }
 }

--- a/infra-ai-hub/modules/vllm-service/outputs.tf
+++ b/infra-ai-hub/modules/vllm-service/outputs.tf
@@ -53,7 +53,7 @@ output "container_image" {
 }
 
 output "model_id" {
-  description = "Hugging Face model ID configured for the vLLM Container App"
+  description = "Canonical model ID configured for the vLLM Container App (used as the APIM-facing model name)"
   value       = var.model_id
 }
 
@@ -63,16 +63,21 @@ output "max_model_len" {
 }
 
 output "model_cache_storage_account_name" {
-  description = "Storage account name backing the persistent Hugging Face model cache"
+  description = "Storage account name backing the persistent model cache"
   value       = azurerm_storage_account.model_cache.name
 }
 
 output "model_cache_share_name" {
-  description = "Azure Files share name backing the persistent Hugging Face model cache"
+  description = "Azure Files share name backing the persistent model cache"
   value       = azurerm_storage_share.model_cache.name
 }
 
 output "workload_profile_type" {
   description = "GPU workload profile type used by the Container App"
   value       = var.workload_profile_type
+}
+
+output "azureml_downloader_principal_id" {
+  description = "Principal ID of the user-assigned managed identity used to download models from AzureML registry. Null when model_source is not azureml_registry."
+  value       = local.use_azureml_registry_source ? azurerm_user_assigned_identity.azureml_downloader[0].principal_id : null
 }

--- a/infra-ai-hub/modules/vllm-service/outputs.tf
+++ b/infra-ai-hub/modules/vllm-service/outputs.tf
@@ -1,0 +1,78 @@
+# -----------------------------------------------------------------------------
+# Private GPU vLLM on Azure Container Apps Module Outputs
+# -----------------------------------------------------------------------------
+
+output "container_app_environment_id" {
+  description = "Resource ID of the vLLM Container Apps environment"
+  value       = azurerm_container_app_environment.vllm.id
+}
+
+output "container_registry_name" {
+  description = "Name of the Azure Container Registry mirroring the vLLM image"
+  value       = azurerm_container_registry.vllm.name
+}
+
+output "container_registry_login_server" {
+  description = "Login server of the Azure Container Registry mirroring the vLLM image"
+  value       = azurerm_container_registry.vllm.login_server
+}
+
+output "container_app_environment_name" {
+  description = "Name of the vLLM Container Apps environment"
+  value       = azurerm_container_app_environment.vllm.name
+}
+
+output "private_endpoint_name" {
+  description = "Name of the private endpoint attached to the vLLM Container Apps environment"
+  value       = azurerm_private_endpoint.vllm_environment.name
+}
+
+output "container_app_name" {
+  description = "Name of the vLLM Container App"
+  value       = azurerm_container_app.vllm.name
+}
+
+output "container_app_fqdn" {
+  description = "FQDN of the vLLM Container App ingress"
+  value       = azurerm_container_app.vllm.ingress[0].fqdn
+}
+
+output "endpoint" {
+  description = "Private HTTPS base URL exposed by the vLLM Container App"
+  value       = format("https://%s", azurerm_container_app.vllm.ingress[0].fqdn)
+}
+
+output "openai_endpoint" {
+  description = "Private OpenAI-compatible /v1 endpoint exposed by the vLLM Container App"
+  value       = format("https://%s/v1", azurerm_container_app.vllm.ingress[0].fqdn)
+}
+
+output "container_image" {
+  description = "Mirrored container image used by the vLLM Container App"
+  value       = local.mirrored_image
+}
+
+output "model_id" {
+  description = "Hugging Face model ID configured for the vLLM Container App"
+  value       = var.model_id
+}
+
+output "max_model_len" {
+  description = "Maximum sequence length exposed by the vLLM server"
+  value       = var.max_model_len
+}
+
+output "model_cache_storage_account_name" {
+  description = "Storage account name backing the persistent Hugging Face model cache"
+  value       = azurerm_storage_account.model_cache.name
+}
+
+output "model_cache_share_name" {
+  description = "Azure Files share name backing the persistent Hugging Face model cache"
+  value       = azurerm_storage_share.model_cache.name
+}
+
+output "workload_profile_type" {
+  description = "GPU workload profile type used by the Container App"
+  value       = var.workload_profile_type
+}

--- a/infra-ai-hub/modules/vllm-service/variables.tf
+++ b/infra-ai-hub/modules/vllm-service/variables.tf
@@ -147,7 +147,7 @@ variable "gpu_memory_utilization" {
 
   validation {
     condition     = var.gpu_memory_utilization >= 0.5 && var.gpu_memory_utilization < 1
-    error_message = "gpu_memory_utilization must be between 0.5 and 1.0."
+    error_message = "gpu_memory_utilization must be at least 0.5 and strictly less than 1.0."
   }
 }
 

--- a/infra-ai-hub/modules/vllm-service/variables.tf
+++ b/infra-ai-hub/modules/vllm-service/variables.tf
@@ -106,9 +106,27 @@ variable "azureml_registry" {
 }
 
 variable "offline_mode" {
-  description = "For model_source = \"huggingface\": whether to force Hugging Face and Transformers into cache-only offline mode so startup uses only files already present on the mounted Azure Files share. Has no effect when model_source = \"azureml_registry\"."
+  description = <<-EOT
+    Controls whether the vLLM container runs in offline mode (no network calls to
+    model registries at runtime).
+
+    When true (default): for HuggingFace source, an init container pre-downloads
+    the model to the persistent Azure Files cache on first deployment and writes a
+    .download-complete marker. Subsequent container restarts skip the download. The
+    main container always starts with HF_HUB_OFFLINE=1 and TRANSFORMERS_OFFLINE=1,
+    guaranteeing zero re-downloads on restart regardless of network availability.
+
+    When false: vLLM downloads the model inline during startup. The HuggingFace
+    library caches to Azure Files, but each restart performs a network check against
+    the HuggingFace Hub to verify model freshness.
+
+    For model_source = "azureml_registry", the AzureML init container always handles
+    the download regardless of this setting. offline_mode controls whether
+    HF_HUB_OFFLINE is set on the main container — recommended to prevent spurious
+    tokenizer fetch calls.
+  EOT
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "max_model_len" {

--- a/infra-ai-hub/modules/vllm-service/variables.tf
+++ b/infra-ai-hub/modules/vllm-service/variables.tf
@@ -1,0 +1,178 @@
+# -----------------------------------------------------------------------------
+# Private GPU vLLM on Azure Container Apps Module Variables
+# -----------------------------------------------------------------------------
+
+variable "app_name" {
+  description = "Name of the application, used for resource naming"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_group_name" {
+  description = "Name of the resource group"
+  type        = string
+  nullable    = false
+}
+
+variable "location" {
+  description = "Azure region for resources"
+  type        = string
+  nullable    = false
+}
+
+variable "infrastructure_subnet_id" {
+  description = "Delegated subnet ID for the Container Apps environment"
+  type        = string
+  nullable    = false
+}
+
+variable "private_endpoint_subnet_id" {
+  description = "Subnet ID for the Container Apps environment private endpoint"
+  type        = string
+  nullable    = false
+}
+
+variable "log_analytics_workspace_id" {
+  description = "Log Analytics Workspace ID for Container Apps diagnostics"
+  type        = string
+  nullable    = false
+}
+
+variable "common_tags" {
+  description = "Common tags to apply to all resources"
+  type        = map(string)
+  nullable    = false
+}
+
+variable "image" {
+  description = "Source vLLM container image used as the upstream base image mirrored or rebuilt into the module-managed Azure Container Registry"
+  type        = string
+  default     = "vllm/vllm-openai:latest"
+}
+
+variable "model_id" {
+  description = "Exact Hugging Face model ID served by the vLLM container"
+  type        = string
+  default     = "google/gemma-4-31B-it"
+}
+
+variable "offline_mode" {
+  description = "Whether to force Hugging Face and Transformers into cache-only offline mode so startup uses only files already present on the mounted Azure Files share"
+  type        = bool
+  default     = false
+}
+
+variable "max_model_len" {
+  description = "Maximum sequence length exposed by the deployed vLLM server"
+  type        = number
+  default     = 32768
+
+  validation {
+    condition     = var.max_model_len >= 4096
+    error_message = "max_model_len must be at least 4096 tokens."
+  }
+}
+
+variable "gpu_memory_utilization" {
+  description = "Target fraction of GPU memory that vLLM is allowed to reserve"
+  type        = number
+  default     = 0.9
+
+  validation {
+    condition     = var.gpu_memory_utilization >= 0.5 && var.gpu_memory_utilization < 1
+    error_message = "gpu_memory_utilization must be between 0.5 and 1.0."
+  }
+}
+
+variable "quantization" {
+  description = "vLLM quantization backend passed as --quantization <value>. Set to null (default) to disable quantization. Must point to a matching pre-quantized HuggingFace model repo — vLLM does not quantize BF16 models on the fly. Common values: awq, gptq, fp8, bitsandbytes."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.quantization == null || trimspace(var.quantization) != ""
+    error_message = "quantization must be null or a non-empty string matching a vLLM-supported quantization backend."
+  }
+}
+
+variable "huggingface_token" {
+  description = "Optional Hugging Face access token injected into the container as HF_TOKEN for higher rate limits or gated models. In hub deployments, source this from the hub Key Vault (data.azurerm_key_vault_secret) in the calling stack rather than storing in tfvars."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "registry_sku" {
+  description = "SKU for the module-managed Azure Container Registry used to mirror the vLLM image"
+  type        = string
+  default     = "Basic"
+
+  validation {
+    condition     = contains(["Basic", "Standard"], var.registry_sku)
+    error_message = "registry_sku must be either Basic or Standard."
+  }
+}
+
+variable "model_cache_share_quota_gb" {
+  description = "Quota in GiB for the Azure Files share that persists Hugging Face model cache data across revisions and replica restarts"
+  type        = number
+  default     = 64
+
+  validation {
+    condition     = var.model_cache_share_quota_gb >= 20
+    error_message = "model_cache_share_quota_gb must be at least 20 GiB."
+  }
+}
+
+variable "workload_profile_name" {
+  description = "Logical name of the GPU workload profile inside the Container Apps environment"
+  type        = string
+  default     = "gpu"
+}
+
+variable "workload_profile_type" {
+  description = "GPU workload profile type to use for the vLLM Container App"
+  type        = string
+  default     = "Consumption-GPU-NC24-A100"
+
+  validation {
+    condition = contains([
+      "Consumption-GPU-NC24-A100",
+      "Consumption-GPU-NC8as-T4",
+    ], var.workload_profile_type)
+    error_message = "workload_profile_type must be either Consumption-GPU-NC24-A100 or Consumption-GPU-NC8as-T4."
+  }
+}
+
+variable "min_replicas" {
+  description = "Minimum number of vLLM replicas. Defaults to 0 (scale-to-zero) for cost efficiency. Note: GPU cold-start for large models (e.g. Gemma 4 31B) takes 5-10 minutes — set to 1 if cold-start latency is unacceptable for your workload."
+  type        = number
+  default     = 0
+}
+
+variable "max_replicas" {
+  description = "Maximum number of vLLM replicas"
+  type        = number
+  default     = 1
+}
+
+variable "scripts_dir" {
+  description = "Path to the scripts directory containing wait-for-dns-zone.sh"
+  type        = string
+  nullable    = false
+}
+
+variable "private_endpoint_dns_wait" {
+  description = "Configuration for waiting on policy-managed DNS zone groups"
+  type = object({
+    timeout       = optional(string, "15m")
+    poll_interval = optional(string, "30s")
+  })
+  default = {}
+}
+
+variable "wait_for_private_endpoint_dns_zone_group" {
+  description = "Whether Terraform should block on policy-managed private DNS zone-group attachment before completing the deployment"
+  type        = bool
+  default     = false
+}

--- a/infra-ai-hub/modules/vllm-service/variables.tf
+++ b/infra-ai-hub/modules/vllm-service/variables.tf
@@ -51,13 +51,62 @@ variable "image" {
 }
 
 variable "model_id" {
-  description = "Exact Hugging Face model ID served by the vLLM container"
+  description = <<-EOT
+    Canonical API-facing model identifier. For model_source = "huggingface": the Hugging Face
+    repo ID passed directly to vllm serve as the --model argument (e.g. "google/gemma-4-31B-it").
+    For model_source = "azureml_registry": the name exposed via --served-model-name so tenants
+    can use the same model= value regardless of the underlying source. In both cases this is the
+    value tenants set in the model= field when calling the API.
+  EOT
   type        = string
   default     = "google/gemma-4-31B-it"
 }
 
+variable "model_source" {
+  description = <<-EOT
+    Source for the model weights served by vLLM. Valid values:
+    - "huggingface"      : Download model weights from Hugging Face Hub at container startup
+                           (default). Set huggingface_token for gated models. Toggle offline_mode
+                           after initial download to prevent repeated HF Hub calls.
+    - "azureml_registry" : Stage model weights from an Azure ML registry using a user-assigned
+                           managed identity and az ml model download in an init container.
+                           Requires azureml_registry to be configured. The model asset must be in
+                           HuggingFace snapshot format — it must contain config.json at the root of
+                           the downloaded directory for vLLM to load it.
+  EOT
+  type        = string
+  default     = "huggingface"
+
+  validation {
+    condition     = contains(["huggingface", "azureml_registry"], var.model_source)
+    error_message = "model_source must be either \"huggingface\" or \"azureml_registry\"."
+  }
+}
+
+variable "azureml_registry" {
+  description = <<-EOT
+    Azure Machine Learning registry configuration. Required when model_source = "azureml_registry".
+    - registry_name        : Short name of the AML registry (e.g. "my-ml-registry").
+    - model_name           : Name of the model asset in the registry. Must match exactly the asset
+                             name used when registering with az ml model create.
+    - model_version        : Version label of the model asset (e.g. "1", "2024-11-01").
+    - registry_resource_id : Full ARM resource ID of the AML registry. Used by the calling stack to
+                             create the AzureML Registry User RBAC assignment scoped to this registry.
+    - subscription_id      : Optional. Azure subscription containing the AML registry. Defaults to
+                             the current deployment subscription when omitted or empty.
+  EOT
+  type = object({
+    registry_name        = string
+    model_name           = string
+    model_version        = string
+    registry_resource_id = string
+    subscription_id      = optional(string, "")
+  })
+  default = null
+}
+
 variable "offline_mode" {
-  description = "Whether to force Hugging Face and Transformers into cache-only offline mode so startup uses only files already present on the mounted Azure Files share"
+  description = "For model_source = \"huggingface\": whether to force Hugging Face and Transformers into cache-only offline mode so startup uses only files already present on the mounted Azure Files share. Has no effect when model_source = \"azureml_registry\"."
   type        = bool
   default     = false
 }
@@ -96,7 +145,7 @@ variable "quantization" {
 }
 
 variable "huggingface_token" {
-  description = "Optional Hugging Face access token injected into the container as HF_TOKEN for higher rate limits or gated models. In hub deployments, source this from the hub Key Vault (data.azurerm_key_vault_secret) in the calling stack rather than storing in tfvars."
+  description = "Optional Hugging Face access token injected into the container as HF_TOKEN for higher rate limits or gated models. Only used when model_source = \"huggingface\". In hub deployments, source this from the hub Key Vault (data.azurerm_key_vault_secret) in the calling stack rather than storing in tfvars."
   type        = string
   default     = ""
   sensitive   = true
@@ -114,7 +163,7 @@ variable "registry_sku" {
 }
 
 variable "model_cache_share_quota_gb" {
-  description = "Quota in GiB for the Azure Files share that persists Hugging Face model cache data across revisions and replica restarts"
+  description = "Quota in GiB for the Azure Files share that persists model cache data across revisions and replica restarts. For huggingface source this holds HF Hub files; for azureml_registry source this holds the staged model directory."
   type        = number
   default     = 64
 

--- a/infra-ai-hub/modules/vllm-service/versions.tf
+++ b/infra-ai-hub/modules/vllm-service/versions.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">= 1.12.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 4.57.0, < 5.0.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 3.2.4, < 4.0.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.7.2, < 4.0.0"
+    }
+    time = {
+      source  = "hashicorp/time"
+      version = ">= 0.13.1, < 1.0.0"
+    }
+  }
+}

--- a/infra-ai-hub/params/apim/api_policy.xml.tftpl
+++ b/infra-ai-hub/params/apim/api_policy.xml.tftpl
@@ -316,7 +316,7 @@
       }
     }
   }]
-  vllm_models = [for m in vllm_models : {
+  vllm_models = vllm_enabled ? [for m in vllm_models : {
     model_id = m.model_id
     backend  = "vllm"
     endpoints = {
@@ -326,7 +326,7 @@
         url      = "${base_url}/${tenant_name}/openai/v1/chat/completions"
       }
     }
-  }]
+  }] : []
   services = {
     openai = {
       enabled         = openai_enabled

--- a/infra-ai-hub/params/apim/api_policy.xml.tftpl
+++ b/infra-ai-hub/params/apim/api_policy.xml.tftpl
@@ -1,6 +1,11 @@
 <policies>
     <inbound>
         <base />
+        <!-- Scrub credential query parameters before forwarding to any backend.       -->
+        <!-- Prevents api-key/subscription-key from leaking to backend logs when       -->
+        <!-- clients use query-string auth and rewrite-uri copy-unmatched-params=true. -->
+        <set-query-parameter name="api-key" exists-action="delete" />
+        <set-query-parameter name="subscription-key" exists-action="delete" />
 %{ if tracking_dimensions_enabled ~}
         <!-- Extract tracking dimensions from headers -->
         <include-fragment fragment-id="tracking-dimensions" />
@@ -91,6 +96,22 @@
 %{ endif ~}
                     </when>
 %{ endfor ~}
+%{ if vllm_enabled ~}
+%{ for model in vllm_models ~}
+                    <!-- Rate limit for vLLM model ${model.model_id}: ${model.tokens_per_minute} TPM -->
+                    <!-- counter-key: "/" is replaced with "-"; model IDs that differ only by slash/hyphen placement
+                         would share a counter. In practice this is impossible for well-formed HuggingFace IDs. -->
+                    <when condition="@(context.Variables.GetValueOrDefault&lt;string&gt;(&quot;deploymentName&quot;, &quot;&quot;) == &quot;${model.model_id}&quot;)">
+                        <llm-token-limit
+                            counter-key="@(context.Subscription.Id + &quot;-vllm-${replace(model.model_id, "/", "-")}&quot;)"
+                            tokens-per-minute="${model.tokens_per_minute}"
+                            estimate-prompt-tokens="true"
+                            remaining-tokens-variable-name="remainingTokens"
+                            remaining-tokens-header-name="x-ratelimit-remaining-tokens"
+                            tokens-consumed-variable-name="tokensConsumed" />
+                    </when>
+%{ endfor ~}
+%{ endif ~}
                     <otherwise>
                         <!-- Fallback rate limit for unknown models: ${tokens_per_minute} TPM -->
                         <llm-token-limit
@@ -295,11 +316,24 @@
       }
     }
   }]
+  vllm_models = [for m in vllm_models : {
+    model_id = m.model_id
+    backend  = "vllm"
+    endpoints = {
+      openai_compatible = {
+        base_url = "${base_url}/${tenant_name}/openai/v1"
+        model    = m.model_id
+        url      = "${base_url}/${tenant_name}/openai/v1/chat/completions"
+      }
+    }
+  }]
   services = {
     openai = {
-      enabled   = openai_enabled
+      enabled         = openai_enabled
+      foundry_enabled = foundry_enabled
+      vllm_enabled    = vllm_enabled
       endpoints = openai_enabled ? {
-        azure_openai      = "${base_url}/${tenant_name}"
+        azure_openai      = foundry_enabled ? "${base_url}/${tenant_name}" : null
         openai_compatible = "${base_url}/${tenant_name}/openai/v1"
         api_version       = "2025-03-01-preview"
       } : null
@@ -362,6 +396,24 @@
                     return &quot;unknown&quot;;
                 }" />
                 <choose>
+%{ if vllm_enabled ~}
+%{ for model in vllm_models ~}
+%{ if length(regexall("/", model.model_id)) > 0 ~}
+                    <!-- Reject ${model.model_id} via /deployments/ URL: slash in model ID means the path -->
+                    <!-- segment would be only "${split("/", model.model_id)[0]}", not the full model ID. -->
+                    <!-- Return 400 so clients get a clear error instead of a Foundry 404. -->
+                    <when condition="@(context.Request.Url.Path.ToLower().Contains(&quot;/deployments/${split("/", model.model_id)[0]}/&quot;))">
+                        <return-response>
+                            <set-status code="400" reason="Bad Request" />
+                            <set-header name="Content-Type" exists-action="override">
+                                <value>application/json</value>
+                            </set-header>
+                            <set-body>{"error":{"code":"UnsupportedRoute","message":"Model '${model.model_id}' cannot be called via the /deployments/ URL format. Use /openai/v1/chat/completions with the 'model' field in the request body."}}</set-body>
+                        </return-response>
+                    </when>
+%{ endif ~}
+%{ endfor ~}
+%{ endif ~}
 %{ for model in model_deployments ~}
                     <when condition="@(context.Variables.GetValueOrDefault&lt;string&gt;(&quot;deploymentName&quot;, &quot;&quot;) == &quot;${model.name}&quot;)">
                         <set-backend-service backend-id="${model.openai_backend_id}" />
@@ -378,7 +430,25 @@
                         <set-variable name="weightedTokensPerMinute" value="@(${model.weighted_tokens_per_minute})" />
                     </when>
 %{ endfor ~}
+%{ if vllm_enabled ~}
+%{ for model in vllm_models ~}
+                    <!-- vLLM dispatch for ${model.model_id}: only matches /v1/ paths -->
+                    <!-- Model IDs containing "/" cannot be expressed in /deployments/ URL format -->
+                    <when condition="@(context.Variables.GetValueOrDefault&lt;string&gt;(&quot;deploymentName&quot;, &quot;&quot;) == &quot;${model.model_id}&quot; &amp;&amp; context.Request.Url.Path.ToLower().Contains(&quot;/v1/&quot;))">
+                        <set-backend-service backend-id="${tenant_name}-vllm" />
+                        <set-variable name="isVllmModel" value="@(true)" />
+                        <set-variable name="backendId" value="@(&quot;${tenant_name}-vllm&quot;)" />
+                        <set-variable name="routeLocation" value="@(&quot;local&quot;)" />
+                        <set-variable name="routeName" value="@(&quot;vllm&quot;)" />
+                        <set-variable name="tokenLimitStrategy" value="@(&quot;raw_tokens_per_minute&quot;)" />
+                        <set-variable name="promptTokensWeight" value="@(1)" />
+                        <set-variable name="completionTokensWeight" value="@(1)" />
+                        <set-variable name="weightedTokensPerMinute" value="@(${model.tokens_per_minute})" />
+                    </when>
+%{ endfor ~}
+%{ endif ~}
                     <otherwise>
+%{ if foundry_enabled ~}
                         <set-backend-service backend-id="${tenant_name}-openai" />
                         <set-variable name="backendId" value="@(&quot;${tenant_name}-openai&quot;)" />
                         <set-variable name="routeLocation" value="@(&quot;canadaeast&quot;)" />
@@ -387,6 +457,16 @@
                         <set-variable name="promptTokensWeight" value="@(1)" />
                         <set-variable name="completionTokensWeight" value="@(1)" />
                         <set-variable name="weightedTokensPerMinute" value="@(${tokens_per_minute})" />
+%{ else ~}
+                        <!-- vLLM-only tenant: no Foundry backend — reject unrecognized model with 400 -->
+                        <return-response>
+                            <set-status code="400" reason="Bad Request" />
+                            <set-header name="Content-Type" exists-action="override">
+                                <value>application/json</value>
+                            </set-header>
+                            <set-body>{"error":{"code":"UnknownModel","message":"The requested model is not available for this tenant. Use /internal/tenant-info to discover supported models."}}</set-body>
+                        </return-response>
+%{ endif ~}
                     </otherwise>
                 </choose>
                 <!-- Validate /v1/ requests: must have valid JSON body with model field -->
@@ -459,6 +539,11 @@
                         var rest = match.Groups[2].Value;
                         return &quot;/openai/deployments/${tenant_name}-&quot; + deploymentName + &quot;/&quot; + rest;
                     }
+                    // vLLM /v1/ paths: strip /openai prefix (vLLM native endpoint is /v1/*)
+                    if (context.Variables.GetValueOrDefault&lt;bool&gt;(&quot;isVllmModel&quot;, false)) {
+                        var vllmMatch = System.Text.RegularExpressions.Regex.Match(path, @&quot;/?openai(/v1/.*)&quot;);
+                        if (vllmMatch.Success) { return vllmMatch.Groups[1].Value; }
+                    }
                     // /v1/ paths: forward as-is (Azure OpenAI handles /openai/v1/ natively)
                     return &quot;/&quot; + path;
                 }" />
@@ -496,7 +581,7 @@
                 <!-- Placed AFTER PII redaction set-body to avoid being overwritten -->
                 <!-- Uses StartsWith guard to prevent double-prefixing -->
                 <choose>
-                    <when condition="@(context.Request.Url.Path.ToLower().Contains(&quot;/v1/&quot;))">
+                    <when condition="@(context.Request.Url.Path.ToLower().Contains(&quot;/v1/&quot;) &amp;&amp; !context.Variables.GetValueOrDefault&lt;bool&gt;(&quot;isVllmModel&quot;, false))">
                         <set-body>@{
                             var body = context.Request.Body.As<JObject>(preserveContent: true);
                             var model = body["model"]?.ToString();
@@ -530,11 +615,28 @@
                         }</set-body>
                     </when>
                 </choose>
+%{ if vllm_enabled ~}
+                <choose>
+                    <when condition="@(!context.Variables.GetValueOrDefault&lt;bool&gt;(&quot;isVllmModel&quot;, false))">
+                        <authentication-managed-identity resource="https://cognitiveservices.azure.com" output-token-variable-name="msi-access-token" ignore-error="false" />
+                        <set-header name="Authorization" exists-action="override">
+                            <value>@("Bearer " + (string)context.Variables["msi-access-token"])</value>
+                        </set-header>
+                        <set-header name="api-key" exists-action="delete" />
+                    </when>
+                    <otherwise>
+                        <!-- vLLM: private network access only; strip auth headers before forwarding -->
+                        <set-header name="Authorization" exists-action="delete" />
+                        <set-header name="api-key" exists-action="delete" />
+                    </otherwise>
+                </choose>
+%{ else ~}
                 <authentication-managed-identity resource="https://cognitiveservices.azure.com" output-token-variable-name="msi-access-token" ignore-error="false" />
                 <set-header name="Authorization" exists-action="override">
                     <value>@("Bearer " + (string)context.Variables["msi-access-token"])</value>
                 </set-header>
                 <set-header name="api-key" exists-action="delete" />
+%{ endif ~}
             </when>
 %{ endif ~}
 %{ if openai_enabled ~}

--- a/infra-ai-hub/params/dev/shared.tfvars
+++ b/infra-ai-hub/params/dev/shared.tfvars
@@ -201,6 +201,62 @@ shared_config = {
     public_network_access_enabled = false
   }
 
+  # ---------------------------------------------------------------------------
+  # vLLM Open-Source Model Service
+  # ---------------------------------------------------------------------------
+  # GPU-backed vLLM deployment on a dedicated Container Apps Environment.
+  # Uses a /27 subnet with Microsoft.App/environments delegation.
+  # The stack serves ONE model per environment — pick one of the examples below.
+  # When model_id changes, update all tenant vllm.models[*].model_id values to match.
+  #
+  # ---- Option A: Phi-4 14B (MIT licence, recommended for low cold-start latency) ----
+  # 14B BF16 weights ≈ 28 GB; KV budget ≈ 44 GB; cold-start ~2–3 min; no HF token.
+  # vllm = {
+  #   enabled                    = true
+  #   model_id                   = "microsoft/phi-4"
+  #   image                      = "vllm/vllm-openai:latest"
+  #   max_model_len              = 32768
+  #   gpu_memory_utilization     = 0.9
+  #   workload_profile_type      = "Consumption-GPU-NC24-A100"
+  #   registry_sku               = "Basic"
+  #   min_replicas               = 0
+  #   max_replicas               = 1
+  #   model_cache_share_quota_gb = 40
+  # }
+
+  # ---- Option B: Qwen3-32B-AWQ (Apache 2.0, 32B INT4, full 32K context) ----
+  # AWQ 4-bit weights ≈ 16 GB; KV budget ≈ 56 GB; cold-start ~5–8 min; no HF token.
+  # Verify the HF repo exists before deploying: https://huggingface.co/Qwen/Qwen3-32B-AWQ
+  # vllm = {
+  #   enabled                    = true
+  #   model_id                   = "Qwen/Qwen3-32B-AWQ"
+  #   quantization               = "awq"
+  #   image                      = "vllm/vllm-openai:latest"
+  #   max_model_len              = 32768
+  #   gpu_memory_utilization     = 0.9
+  #   workload_profile_type      = "Consumption-GPU-NC24-A100"
+  #   registry_sku               = "Basic"
+  #   min_replicas               = 0
+  #   max_replicas               = 1
+  #   model_cache_share_quota_gb = 24
+  # }
+
+  # ---- Option C: Gemma 4 31B-it (Gemma ToU, gated — requires HF token) ----
+  # 31B BF16 weights ≈ 62 GB; cold-start ~5–10 min; aca_proxy.py SSE workaround active.
+  # vllm = {
+  #   enabled                    = true
+  #   model_id                   = "google/gemma-4-31B-it"
+  #   image                      = "vllm/vllm-openai:latest"
+  #   max_model_len              = 32768
+  #   gpu_memory_utilization     = 0.9
+  #   workload_profile_type      = "Consumption-GPU-NC24-A100"
+  #   registry_sku               = "Basic"
+  #   min_replicas               = 0
+  #   max_replicas               = 1
+  #   model_cache_share_quota_gb = 64
+  #   huggingface_secret_name    = "huggingface-token"
+  # }
+
 }
 
 # =============================================================================

--- a/infra-ai-hub/params/test/shared.tfvars
+++ b/infra-ai-hub/params/test/shared.tfvars
@@ -200,6 +200,62 @@ shared_config = {
     alert_emails = ["omprakash.2.mishra@gov.bc.ca"]
   }
 
+  # ---------------------------------------------------------------------------
+  # vLLM Open-Source Model Service
+  # ---------------------------------------------------------------------------
+  # GPU-backed vLLM deployment on a dedicated Container Apps Environment.
+  # Uses a /27 subnet with Microsoft.App/environments delegation.
+  # The stack serves ONE model per environment — pick one of the examples below.
+  # When model_id changes, update all tenant vllm.models[*].model_id values to match.
+  #
+  # ---- Option A: Phi-4 14B (MIT licence, recommended for low cold-start latency) ----
+  # 14B BF16 weights ≈ 28 GB; KV budget ≈ 44 GB; cold-start ~2–3 min; no HF token.
+  # vllm = {
+  #   enabled                    = true
+  #   model_id                   = "microsoft/phi-4"
+  #   image                      = "vllm/vllm-openai:latest"
+  #   max_model_len              = 32768
+  #   gpu_memory_utilization     = 0.9
+  #   workload_profile_type      = "Consumption-GPU-NC24-A100"
+  #   registry_sku               = "Basic"
+  #   min_replicas               = 0
+  #   max_replicas               = 1
+  #   model_cache_share_quota_gb = 40
+  # }
+
+  # ---- Option B: Qwen3-32B-AWQ (Apache 2.0, 32B INT4, full 32K context) ----
+  # AWQ 4-bit weights ≈ 16 GB; KV budget ≈ 56 GB; cold-start ~5–8 min; no HF token.
+  # Verify the HF repo exists before deploying: https://huggingface.co/Qwen/Qwen3-32B-AWQ
+  # vllm = {
+  #   enabled                    = true
+  #   model_id                   = "Qwen/Qwen3-32B-AWQ"
+  #   quantization               = "awq"
+  #   image                      = "vllm/vllm-openai:latest"
+  #   max_model_len              = 32768
+  #   gpu_memory_utilization     = 0.9
+  #   workload_profile_type      = "Consumption-GPU-NC24-A100"
+  #   registry_sku               = "Basic"
+  #   min_replicas               = 0
+  #   max_replicas               = 1
+  #   model_cache_share_quota_gb = 24
+  # }
+
+  # ---- Option C: Gemma 4 31B-it (Gemma ToU, gated — requires HF token) ----
+  # 31B BF16 weights ≈ 62 GB; cold-start ~5–10 min; aca_proxy.py SSE workaround active.
+  # vllm = {
+  #   enabled                    = true
+  #   model_id                   = "google/gemma-4-31B-it"
+  #   image                      = "vllm/vllm-openai:latest"
+  #   max_model_len              = 32768
+  #   gpu_memory_utilization     = 0.9
+  #   workload_profile_type      = "Consumption-GPU-NC24-A100"
+  #   registry_sku               = "Basic"
+  #   min_replicas               = 0
+  #   max_replicas               = 1
+  #   model_cache_share_quota_gb = 64
+  #   huggingface_secret_name    = "huggingface-token"
+  # }
+
 }
 
 # =============================================================================

--- a/infra-ai-hub/params/test/tenants/README.md
+++ b/infra-ai-hub/params/test/tenants/README.md
@@ -119,6 +119,20 @@ tenant = {
     ]
   }
 
+  # vLLM — opt-in to GPU-backed open-source models (shared hub infrastructure).
+  # Each model entry can override tokens_per_minute independently; if omitted the
+  # tenant-level rate_limiting.tokens_per_minute is used as the per-model default.
+  # Requires the vllm stack to be deployed for this environment first.
+  # vllm = {
+  #   enabled = true
+  #   models = [
+  #     {
+  #       model_id          = "google/gemma-4-31B-it"
+  #       tokens_per_minute = 50000  # optional; defaults to rate_limiting.tokens_per_minute
+  #     },
+  #   ]
+  # }
+
   apim_auth = {
     mode                 = "subscription_key"
     key_rotation_enabled = false  # Per-tenant opt-in for APIM key rotation
@@ -218,6 +232,17 @@ Each service can be independently enabled/disabled via the `enabled` flag (JSON 
 - `Session` - Recommended for most use cases
 - `BoundedStaleness`
 - `Strong` - Most restrictive
+
+### vLLM Model IDs
+
+The `model_id` field must exactly match the model ID on the shared vLLM Container App. The default model deployed in each environment is listed in `infra-ai-hub/model-deployments.md`.
+
+**Token limits:**
+- `tokens_per_minute` (per model, optional) — rate cap applied by APIM for this specific model. Defaults to the tenant-level `rate_limiting.tokens_per_minute` when omitted.
+- Models that share the same `tokens_per_minute` still receive **independent counters** keyed by `{subscription-id}-vllm-{model-id}`, so a high-usage model does not consume another model's quota.
+
+**Namespace collision rule:**
+`model_id` values must not share a prefix (text before the first `/`) with any Foundry deployment `name` in the same tenant. Terraform validates this at plan time.
 
 ### OpenAI Model Names
 Common models available in Azure OpenAI:

--- a/infra-ai-hub/scripts/deploy-scaled.sh
+++ b/infra-ai-hub/scripts/deploy-scaled.sh
@@ -5,8 +5,8 @@
 # Executes Terraform across isolated stack roots in dependency order:
 #   Phase 1: shared
 #   Phase 2: tenant (per-tenant, parallel)
-#   Phase 3: foundry + tenant-user-mgmt + pii-redaction (in parallel)
-#   Phase 3b: apim (after pii-redaction — reads its FQDN via remote state)
+#   Phase 3: foundry + tenant-user-mgmt + pii-redaction + vllm (in parallel)
+#   Phase 3b: apim (after pii-redaction and vllm — reads their FQDNs via remote state)
 #   Phase 4:  key-rotation (depends on APIM outputs from phase 3b)
 # For destroy, execution is reversed.
 #
@@ -588,6 +588,7 @@ stack_state_key() {
     tenant-user-mgmt) echo "ai-services-hub/${ENVIRONMENT}/tenant-user-management.tfstate" ;;
     key-rotation) echo "ai-services-hub/${ENVIRONMENT}/key-rotation.tfstate" ;;
     pii-redaction) echo "ai-services-hub/${ENVIRONMENT}/pii-redaction.tfstate" ;;
+    vllm) echo "ai-services-hub/${ENVIRONMENT}/vllm.tfstate" ;;
     *) echo "" ;;
   esac
 }
@@ -861,15 +862,21 @@ run_pii_redaction() {
   tf_run_stack pii-redaction "$1" "${INFRA_DIR}/.tenants-${ENVIRONMENT}.auto.tfvars"
 }
 
+run_vllm() {
+  tf_init_stack vllm
+  tf_run_stack vllm "$1" "${INFRA_DIR}/params/${ENVIRONMENT}/shared.tfvars"
+}
+
 # ---------------------------------------------------------------------------
-# Phase 3 parallel runner — foundry + tenant-user-mgmt + pii-redaction run
-# concurrently once shared+tenant are done.  APIM is NOT included here because
-# the APIM stack reads pii-redaction FQDN via remote state (Phase 3b, sequential).
+# Phase 3 parallel runner — foundry + tenant-user-mgmt + pii-redaction + vllm
+# run concurrently once shared+tenant are done.  APIM is NOT included here
+# because the APIM stack reads pii-redaction and vllm FQDNs via remote state
+# (Phase 3b, sequential).
 # ---------------------------------------------------------------------------
 run_phase3_parallel() {
   local action="$1"
-  local names=("foundry" "tenant-user-mgmt" "pii-redaction")
-  local runners=("run_foundry" "run_tenant_user_mgmt" "run_pii_redaction")
+  local names=("foundry" "tenant-user-mgmt" "pii-redaction" "vllm")
+  local runners=("run_foundry" "run_tenant_user_mgmt" "run_pii_redaction" "run_vllm")
   local pids=()
   local logs=()
 

--- a/infra-ai-hub/stacks/apim/locals.tf
+++ b/infra-ai-hub/stacks/apim/locals.tf
@@ -12,6 +12,10 @@ locals {
 
   key_rotation_config = local.apim_config.key_rotation
 
+  # Whether the vLLM remote state has been initialised with a vllm_service output.
+  # Guards vLLM backend resource creation; avoids plan failure if vLLM stack not yet applied.
+  vllm_state_available = try(data.terraform_remote_state.vllm.outputs.vllm_service, null) != null
+
   # ---------------------------------------------------------------------------
   # PE subnet resolution for APIM
   # APIM is pinned — null key uses primary; explicit key must exist in PE pool.
@@ -176,10 +180,20 @@ locals {
     for key, config in local.enabled_tenants : key => templatefile(
       "${path.root}/../../params/apim/api_policy.xml.tftpl",
       {
-        tenant_name                    = key
-        tokens_per_minute              = try(config.apim_policies.rate_limiting.tokens_per_minute, 10000)
-        model_deployments              = local.tenant_model_deployments[key]
-        openai_enabled                 = length(try(config.openai.model_deployments, [])) > 0
+        tenant_name       = key
+        tokens_per_minute = try(config.apim_policies.rate_limiting.tokens_per_minute, 10000)
+        model_deployments = local.tenant_model_deployments[key]
+        openai_enabled    = length(try(config.openai.model_deployments, [])) > 0 || (try(config.vllm.enabled, false) && local.vllm_state_available)
+        foundry_enabled   = length(try(config.openai.model_deployments, [])) > 0
+        vllm_enabled      = try(config.vllm.enabled, false) && local.vllm_state_available
+        # Each vLLM model entry gets a default tokens_per_minute equal to the tenant's
+        # overall rate-limit cap when not explicitly set per model.
+        vllm_models = [
+          for m in try(config.vllm.models, []) : merge(
+            { tokens_per_minute = try(config.apim_policies.rate_limiting.tokens_per_minute, 10000) },
+            m
+          )
+        ]
         document_intelligence_enabled  = try(config.document_intelligence.enabled, false)
         ai_search_enabled              = try(config.ai_search.enabled, false)
         speech_services_enabled        = try(config.speech_services.enabled, false)
@@ -279,5 +293,49 @@ check "provisioned_backend_routing_alignment" {
   assert {
     condition     = alltrue(values(local.tenant_backend_routing_is_valid))
     error_message = "One or more OpenAI deployments render with the wrong APIM backend id. PTU deployments must use <tenant>-openai-ptu and non-PTU deployments must use <tenant>-openai."
+  }
+}
+
+# Guard: if a Foundry deployment name equals the namespace prefix of a slash-containing
+# vLLM model ID (e.g. deployment "google" and vLLM model "google/gemma-4-31B-it"),
+# the /deployments/ 400-guard in the API policy would incorrectly block that Foundry path.
+check "vllm_foundry_namespace_collision" {
+  assert {
+    condition = !anytrue(flatten([
+      for key, config in local.enabled_tenants : [
+        for vllm_model in(try(config.vllm.enabled, false) && local.vllm_state_available ? try(config.vllm.models, []) : []) : [
+          for deployment in local.tenant_model_deployments[key] :
+          length(regexall("/", vllm_model.model_id)) > 0 &&
+          deployment.name == split("/", vllm_model.model_id)[0]
+        ]
+      ]
+    ]))
+    error_message = "A Foundry deployment name collides with a vLLM model ID namespace prefix (e.g. deployment 'google' and vLLM model 'google/gemma-4-31B-it'). The /deployments/ 400-guard would incorrectly block valid Foundry requests. Rename the conflicting deployment or change the vLLM model ID."
+  }
+}
+
+# Guard: a vLLM-enabled tenant must declare at least one model — empty models list
+# produces a backend with no routing rules or rate limits (silently inert or 400-only).
+check "vllm_enabled_requires_models" {
+  assert {
+    condition = alltrue([
+      for key, config in local.enabled_tenants :
+      !try(config.vllm.enabled, false) || length(try(config.vllm.models, [])) > 0
+    ])
+    error_message = "One or more tenants have vllm.enabled = true but vllm.models is empty or missing. Each vLLM-enabled tenant must declare at least one model in vllm.models[*].model_id."
+  }
+}
+
+# Guard: each tenant's vLLM model_id must match the model actually deployed on the shared
+# vLLM service. When vllm_state_available is false, skip this check (vLLM not yet deployed).
+check "vllm_model_id_matches_deployed_model" {
+  assert {
+    condition = !local.vllm_state_available || alltrue([
+      for key, config in local.enabled_tenants : alltrue([
+        for model in(try(config.vllm.enabled, false) ? try(config.vllm.models, []) : []) :
+        model.model_id == try(data.terraform_remote_state.vllm.outputs.vllm_service.model_id, model.model_id)
+      ])
+    ])
+    error_message = "One or more tenants reference a vLLM model_id that does not match the deployed vLLM service model ('${try(data.terraform_remote_state.vllm.outputs.vllm_service.model_id, "unknown")}'). Update vllm.models[*].model_id in the affected tenant configs."
   }
 }

--- a/infra-ai-hub/stacks/apim/locals.tf
+++ b/infra-ai-hub/stacks/apim/locals.tf
@@ -326,6 +326,18 @@ check "vllm_enabled_requires_models" {
   }
 }
 
+# Guard: if any tenant enables vLLM but the vLLM stack remote state is unavailable,
+# vLLM routing is silently skipped. Warn operators so they know to deploy stacks/vllm first.
+check "vllm_enabled_requires_deployed_state" {
+  assert {
+    condition = local.vllm_state_available || !anytrue([
+      for key, config in local.enabled_tenants :
+      try(config.vllm.enabled, false)
+    ])
+    error_message = "One or more tenants have vllm.enabled = true but the vLLM stack remote state is not available. Deploy infra-ai-hub/stacks/vllm before enabling vLLM on tenants."
+  }
+}
+
 # Guard: each tenant's vLLM model_id must match the model actually deployed on the shared
 # vLLM service. When vllm_state_available is false, skip this check (vLLM not yet deployed).
 check "vllm_model_id_matches_deployed_model" {

--- a/infra-ai-hub/stacks/apim/main.tf
+++ b/infra-ai-hub/stacks/apim/main.tf
@@ -44,6 +44,25 @@ data "terraform_remote_state" "pii_redaction" {
   }
 }
 
+# The azurerm backend returns empty state (not an error) when the state blob does not
+# yet exist. When the vllm_service output is absent, local.vllm_state_available = false
+# and no vLLM backends or policy routing are created — APIM plans cleanly without vLLM.
+# On first full deployment, vllm apply (phase 3) runs before apim apply (phase 3b),
+# so the state blob exists by the time APIM apply runs.
+data "terraform_remote_state" "vllm" {
+  backend = "azurerm"
+  config = {
+    resource_group_name  = var.backend_resource_group
+    storage_account_name = var.backend_storage_account
+    container_name       = var.backend_container_name
+    key                  = "ai-services-hub/${var.app_env}/vllm.tfstate"
+    subscription_id      = var.subscription_id
+    tenant_id            = var.tenant_id
+    client_id            = var.client_id
+    use_oidc             = var.use_oidc
+  }
+}
+
 module "apim" {
   source = "../../modules/apim"
   count  = local.apim_config.enabled ? 1 : 0
@@ -228,6 +247,57 @@ resource "azurerm_api_management_backend" "openai_ptu" {
         min = 500
         max = 599
       }
+    }
+  }
+}
+
+resource "azurerm_api_management_backend" "vllm" {
+  for_each = {
+    for key, config in local.enabled_tenants : key => config
+    if try(config.vllm.enabled, false) && local.apim_config.enabled && local.vllm_state_available
+  }
+
+  name                = "${each.key}-vllm"
+  resource_group_name = data.terraform_remote_state.shared.outputs.resource_group_name
+  api_management_name = module.apim[0].name
+  protocol            = "http"
+  url                 = "https://${data.terraform_remote_state.vllm.outputs.vllm_service.container_app_fqdn}"
+  description         = "vLLM open-source model backend for ${each.value.display_name}"
+
+  # Circuit breaker: trip on persistent hard errors only.
+  # 503 is intentionally excluded — vLLM returns 503 during normal GPU cold-start
+  # (scale-to-zero, 5–10 min warm-up). Tripping on 503 would block all cold-start
+  # traffic. Tenants with latency SLAs should use min_replicas = 1 to avoid cold start.
+  circuit_breaker_rule {
+    name                       = "vllm-breaker"
+    trip_duration              = "PT2M"
+    accept_retry_after_enabled = true
+
+    failure_condition {
+      count             = 5
+      interval_duration = "PT2M"
+
+      # 500–502: server errors (not model loading)
+      status_code_range {
+        min = 500
+        max = 502
+      }
+
+      # 504–599: timeouts and other hard failures (not 503 model-loading unavailability)
+      status_code_range {
+        min = 504
+        max = 599
+      }
+    }
+  }
+
+  lifecycle {
+    precondition {
+      condition = length([
+        for vllm_model in try(each.value.vllm.models, []) : vllm_model.model_id
+        if contains([for m in try(each.value.openai.model_deployments, []) : m.name], vllm_model.model_id)
+      ]) == 0
+      error_message = "vLLM model_id conflicts with a Foundry deployment name in tenant '${each.key}'. Model IDs must be unique per tenant to avoid routing ambiguity."
     }
   }
 }
@@ -619,6 +689,7 @@ resource "azurerm_api_management_api_policy" "tenant" {
     azurerm_api_management_backend.ai_search,
     azurerm_api_management_backend.speech_services_stt,
     azurerm_api_management_backend.speech_services_tts,
+    azurerm_api_management_backend.vllm,
     azurerm_api_management_named_value.ai_foundry_endpoint,
     azurerm_api_management_named_value.openai_endpoint,
     azurerm_api_management_named_value.docint_endpoint,

--- a/infra-ai-hub/stacks/shared/outputs.tf
+++ b/infra-ai-hub/stacks/shared/outputs.tf
@@ -49,6 +49,11 @@ output "aca_subnet_id" {
   value       = module.network.aca_subnet_id
 }
 
+output "vllm_aca_subnet_id" {
+  description = "vLLM ACA subnet ID for the GPU-backed Container Apps Environment (null if not enabled)"
+  value       = module.network.vllm_aca_subnet_id
+}
+
 output "container_app_environment_id" {
   description = "Container App Environment resource ID (null if not enabled)"
   value       = length(module.container_app_environment) > 0 ? module.container_app_environment[0].resource_id : null

--- a/infra-ai-hub/stacks/vllm/README.md
+++ b/infra-ai-hub/stacks/vllm/README.md
@@ -187,9 +187,11 @@ the Azure tenant. It is recommended when:
 ### How it works
 
 1. The module creates a **user-assigned managed identity** (`azureml-downloader`).
-2. The stack assigns the `AzureML Registry User` built-in role to that identity at
+2. The module assigns the `AzureML Registry User` built-in role to that identity at
    the registry scope (see `azurerm_role_assignment.azureml_registry_user` in
-   `stacks/vllm/main.tf`).
+   `modules/vllm-service/main.tf`). The role assignment is in the module's
+   `depends_on` chain for the Container App, preventing the init container from
+   starting before RBAC has propagated.
 3. On the first Container App start, an **init container** (`azureml-init`) runs:
    - Logs in with the UA identity via `az login --identity --client-id`.
    - Downloads `{model_name}:{model_version}` from the registry to a temp dir.
@@ -231,9 +233,11 @@ vllm = {
 
 ### RBAC wiring
 
-The `azurerm_role_assignment.azureml_registry_user` resource in `stacks/vllm/main.tf`
+The `azurerm_role_assignment.azureml_registry_user` resource in `modules/vllm-service/main.tf`
 assigns `AzureML Registry User` at the registry scope to the module-managed UA identity.
 The role assignment is created automatically at deploy time — no manual step needed.
+It is also listed in the Container App's `depends_on` block, ensuring the init container
+cannot start before RBAC is effective (eliminates the propagation race at provision time).
 
 For **community registries** (`azureml`, `HuggingFace`), the role assignment is still
 required but the registry resource ID follows the pattern:

--- a/infra-ai-hub/stacks/vllm/README.md
+++ b/infra-ai-hub/stacks/vllm/README.md
@@ -49,6 +49,30 @@ Gemma 4 31B cold start is **5–10 minutes** after the first request. Operators 
 override with `min_replicas = 1` in `params/{env}/shared.tfvars` when lower
 first-token latency is required.
 
+## Model Caching & Offline Mode
+
+Model weights are persisted on a **dedicated Azure Files share** mounted at
+`/model-cache` on every container instance. This share survives container restarts,
+scale-to-zero events, and revision updates — models are downloaded once and reused
+indefinitely.
+
+`offline_mode = true` (the default) ensures **zero re-downloads on restart**:
+
+- **HuggingFace source:** An init container pre-downloads the model to Azure Files
+  and writes a `.download-complete` marker. The main vLLM container starts with
+  `HF_HUB_OFFLINE=1` and `TRANSFORMERS_OFFLINE=1`, using only cached files.
+- **AzureML registry source:** The AzureML init container stages the model to
+  Azure Files with its own `.download-complete` marker (always active regardless
+  of `offline_mode`). `offline_mode` additionally sets `HF_HUB_OFFLINE=1` on the
+  main container to prevent spurious tokenizer fetch calls.
+
+To force a model re-download (e.g. after an upstream update), delete the
+`.download-complete` marker from the Azure Files share and restart the container.
+
+Setting `offline_mode = false` reverts to legacy behaviour: the main vLLM process
+downloads the model inline during its startup probe window, and each restart
+performs a network check against the HuggingFace Hub to verify model freshness.
+
 **Single-replica SLA note** - Azure Container Apps' published service-level
 commitment for Container Apps is **99.95%** uptime. However, keeping one replica
 warm only removes the scale-from-zero cold start; it does **not** make this vLLM

--- a/infra-ai-hub/stacks/vllm/README.md
+++ b/infra-ai-hub/stacks/vllm/README.md
@@ -42,12 +42,27 @@ it must complete before APIM is planned.
 
 The `deploy-scaled.sh` engine enforces this ordering automatically.
 
-## Cold Start
+## Cold Start / Availability
 
 `min_replicas = 0` (scale-to-zero) is the default to avoid continuous GPU billing.
 Gemma 4 31B cold start is **5–10 minutes** after the first request. Operators can
-override with `min_replicas = 1` in `params/{env}/shared.tfvars` when latency SLA
-is required.
+override with `min_replicas = 1` in `params/{env}/shared.tfvars` when lower
+first-token latency is required.
+
+**Single-replica SLA note** - Azure Container Apps' published service-level
+commitment for Container Apps is **99.95%** uptime. However, keeping one replica
+warm only removes the scale-from-zero cold start; it does **not** make this vLLM
+path zone-redundant or multi-replica. The current module creates the Container
+Apps environment with `zone_redundancy_enabled = false`, and Microsoft guidance
+for zone-redundant Container Apps requires a zone-redundant environment plus a
+minimum replica count of at least two to distribute replicas across availability
+zones.
+
+**Sources**
+- [SLA for Azure Container Apps](https://azure.microsoft.com/en-us/support/legal/sla/container-apps/v1_0/)
+- [Service Level Agreements for Online Services (Microsoft Licensing)](https://www.microsoft.com/licensing/docs/view/service-level-agreements-sla-for-online-services?lang=1)
+- [Reliability in Azure Container Apps - zone redundancy requirements](https://learn.microsoft.com/en-us/azure/reliability/reliability-azure-container-apps#requirements)
+- [`../../modules/vllm-service/main.tf`](../../modules/vllm-service/main.tf) (`zone_redundancy_enabled = false`)
 
 ## Configuration
 

--- a/infra-ai-hub/stacks/vllm/README.md
+++ b/infra-ai-hub/stacks/vllm/README.md
@@ -1,0 +1,160 @@
+# vLLM Stack
+
+Deploys a GPU-backed vLLM Container App (shared per hub environment) that serves
+open-source models via an OpenAI-compatible API. Tenants access it through APIM
+using the same `/openai/v1` base URL as Foundry — the `model=` field in the request
+body selects the backend.
+
+## Architecture
+
+```
+Tenant client
+     │
+     ▼  (api-key)
+APIM /openai/v1/chat/completions
+     │  model = "google/gemma-4-31B-it"
+     │
+     ▼  (no auth headers forwarded)
+vLLM Container App (GPU)
+  • Azure Container Apps (GPU workload profile: Consumption-GPU-NC24-A100)
+  • Dedicated /27 subnet (vllm-aca-subnet) with Microsoft.App/environments delegation
+  • Private endpoint for inbound access from APIM
+  • HuggingFace token from Key Vault for model weight download
+```
+
+## Shared vs Per-Tenant
+
+vLLM is **shared infrastructure** — one GPU Container Apps Environment per hub
+environment. All tenants that have `vllm.enabled = true` route to the same vLLM
+instance. Circuit-breaker isolation is maintained per tenant via separate APIM
+backend entities (same FQDN, different names).
+
+## State
+
+- State key: `ai-services-hub/{env}/vllm.tfstate`
+- Remote state consumed by: `apim` stack (reads `vllm_service.container_app_fqdn`)
+
+## Deploy Ordering
+
+Phase 3 (parallel with `foundry`, `pii-redaction`, `tenant-user-mgmt`). The `apim`
+stack (Phase 3b) reads this stack's outputs via `data.terraform_remote_state.vllm` —
+it must complete before APIM is planned.
+
+The `deploy-scaled.sh` engine enforces this ordering automatically.
+
+## Cold Start
+
+`min_replicas = 0` (scale-to-zero) is the default to avoid continuous GPU billing.
+Gemma 4 31B cold start is **5–10 minutes** after the first request. Operators can
+override with `min_replicas = 1` in `params/{env}/shared.tfvars` when latency SLA
+is required.
+
+## Configuration
+
+Enable the vLLM stack by uncommenting the `vllm` block in `params/{env}/shared.tfvars`.
+Three model options are documented there — see [model-deployments.md](../../model-deployments.md#vllm-model-catalogue)
+for memory estimates and licence details.
+
+**Quick example (Phi-4 — no HF token, no quantization):**
+
+```hcl
+vllm = {
+  enabled                    = true
+  model_id                   = "microsoft/phi-4"
+  max_model_len              = 32768
+  model_cache_share_quota_gb = 40
+}
+```
+
+**Quick example (Qwen3-32B-AWQ — Apache 2.0, INT4, full context):**
+
+```hcl
+vllm = {
+  enabled                    = true
+  model_id                   = "Qwen/Qwen3-32B-AWQ"
+  quantization               = "awq"
+  max_model_len              = 32768
+  model_cache_share_quota_gb = 24
+}
+```
+
+> **Switching models:** When `model_id` changes, update all tenant
+> `vllm.models[*].model_id` values to the new ID or the
+> `check "vllm_model_id_matches_deployed_model"` validation block will emit
+> a warning at plan time.
+
+Enable vLLM routing for a tenant in `params/{env}/tenants/{tenant}/tenant.tfvars`:
+
+```hcl
+vllm = {
+  enabled = true
+  models = [
+    {
+      model_id = "google/gemma-4-31B-it"
+    }
+  ]
+}
+```
+
+## Inputs (from shared remote state)
+
+| Output | Description |
+|--------|-------------|
+| `vllm_aca_subnet_id` | Subnet ID for the GPU Container Apps Environment |
+| `private_endpoint_subnet_id` | Primary PE subnet for private endpoint placement |
+| `log_analytics_workspace_id` | Workspace for diagnostics |
+| `hub_keyvault_id` | Key Vault containing the HuggingFace token |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `vllm_service.container_app_fqdn` | Internal FQDN used as APIM backend URL |
+| `vllm_service.openai_endpoint` | Full OpenAI-compatible endpoint URL |
+| `vllm_service.model_id` | Model ID being served |
+| `vllm_service.max_model_len` | Context window length |
+| `vllm_service.workload_profile_type` | GPU workload profile name |
+
+## ACR Note
+
+The `vllm-service` module builds a custom container image via an `acr build`
+provisioner. The hub ACR has `public_network_access_enabled = true`, so the
+`acr build` provisioner task completes without requiring private network access
+or Premium SKU. `admin_enabled = true` is still required for the Container App
+to pull images using registry credentials.
+
+## Known Limitations
+
+**GPU workload profile drift** — The `null_resource.gpu_workload_profile` adds
+the GPU workload profile if it is absent. It does not reconcile an existing
+profile when `workload_profile_type` or `workload_profile_name` changes in
+tfvars. To change the GPU profile, delete the existing profile from the CAE
+manually (`az containerapp env workload-profile delete`) before re-running
+`apply`, or replace the CAE resource.
+
+**Model-cache storage public access** — `azurerm_storage_account.model_cache`
+has `public_network_access_enabled = true`. The share requires the storage
+access key for access (nested public access is blocked), but the Azure Files
+SMB endpoint is reachable from the internet. A future iteration should add a
+`privatelink.file.core.windows.net` private endpoint and set
+`public_network_access_enabled = false` to align with the hub's private-only
+PaaS pattern.
+
+**vLLM backend is network-trusted with no application-layer auth** — The
+Container App Environment's private endpoint is placed in the shared PE subnet.
+Any workload with network reach to that subnet (e.g., a tenant jumpbox) can
+call the vLLM endpoint directly without going through APIM, bypassing tenant
+subscription auth, rate limits, PII redaction, and logging. Azure OpenAI
+(Foundry) is subject to the same VNet-level trust but enforces its own API key
+independently. To strengthen this, either scope the vLLM PE subnet NSG to allow
+inbound only from the APIM subnet, or add an application-layer shared secret
+header validated by a proxy sidecar.
+
+**Secrets in Terraform state** — Two sensitive values are stored in the
+azurerm backend state blob: the ACR admin password (`azurerm_container_registry.admin_password`)
+and, when used, the Hugging Face token read from Key Vault. `sensitive = true`
+hides these from CLI output but does not prevent them from appearing as
+plaintext in the state blob. Restrict state-blob read access to the deployment
+service principal and platform operators. A future iteration should use managed
+identity for ACR pulls (replacing admin creds) and use a Key Vault-backed
+Container App secret reference to avoid materialising the HF token in state.

--- a/infra-ai-hub/stacks/vllm/README.md
+++ b/infra-ai-hub/stacks/vllm/README.md
@@ -173,3 +173,72 @@ plaintext in the state blob. Restrict state-blob read access to the deployment
 service principal and platform operators. A future iteration should use managed
 identity for ACR pulls (replacing admin creds) and use a Key Vault-backed
 Container App secret reference to avoid materialising the HF token in state.
+
+## AzureML Registry Source
+
+You can stage model weights from an Azure Machine Learning registry instead of
+HuggingFace Hub. This avoids HF token management and keeps model assets inside
+the Azure tenant. It is recommended when:
+- The model is available in the [Azure AI model catalogue](https://ai.azure.com/explore/models)
+  and you want to avoid coupling the hub to Hugging Face rate limits or gating.
+- You need to store a fine-tuned or internally registered model version alongside
+  standard open-source models.
+
+### How it works
+
+1. The module creates a **user-assigned managed identity** (`azureml-downloader`).
+2. The stack assigns the `AzureML Registry User` built-in role to that identity at
+   the registry scope (see `azurerm_role_assignment.azureml_registry_user` in
+   `stacks/vllm/main.tf`).
+3. On the first Container App start, an **init container** (`azureml-init`) runs:
+   - Logs in with the UA identity via `az login --identity --client-id`.
+   - Downloads `{model_name}:{model_version}` from the registry to a temp dir.
+   - Validates `config.json` presence (HuggingFace snapshot format required).
+   - Atomically moves the download to `{download_parent}/{model_name}`.
+   - Writes a `.download-complete` marker so subsequent starts skip the download.
+4. The vLLM container starts with `--model {staged_path}` and
+   `--served-model-name {var.model_id}` so the APIM-facing model name is unchanged.
+
+### Requirements
+
+- **AzureML registry** must exist and be accessible from the hub subscription.
+  Community registries (e.g. `azureml`, `HuggingFace`) are available without
+  setup. For internal registries, ensure the hub service principal has at least
+  `Reader` on the registry resource.
+- **Model format:** the registered model must be in **HuggingFace snapshot format**
+  (contains `config.json` at the root). If the registry asset was uploaded from a
+  non-HF source, the init script will abort with a validation error.
+- **Expected staging time:** 5–20 minutes on first deploy, depending on model
+  weight size. The Container App `timeouts.create = 90m` covers this.
+
+### tfvars example
+
+```hcl
+vllm = {
+  enabled      = true
+  model_id     = "microsoft/phi-4"   # canonical API-facing name
+  model_source = "azureml_registry"
+  azureml_registry = {
+    registry_name       = "azureml"                           # or "HuggingFace", or your own
+    model_name          = "phi-4"
+    model_version       = "1"
+    registry_resource_id = "/subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.MachineLearningServices/registries/azureml"
+    subscription_id     = "{subscription_id}"                 # optional; defaults to current
+  }
+  model_cache_share_quota_gb = 40
+}
+```
+
+### RBAC wiring
+
+The `azurerm_role_assignment.azureml_registry_user` resource in `stacks/vllm/main.tf`
+assigns `AzureML Registry User` at the registry scope to the module-managed UA identity.
+The role assignment is created automatically at deploy time — no manual step needed.
+
+For **community registries** (`azureml`, `HuggingFace`), the role assignment is still
+required but the registry resource ID follows the pattern:
+```
+/subscriptions/{pub-sub}/resourceGroups/{rg}/providers/Microsoft.MachineLearningServices/registries/{name}
+```
+The subscription ID for community registries belongs to Microsoft, not your tenant.
+To get the exact ARM ID: `az ml registry show --name azureml --query id -o tsv`.

--- a/infra-ai-hub/stacks/vllm/backend.tf
+++ b/infra-ai-hub/stacks/vllm/backend.tf
@@ -1,0 +1,3 @@
+terraform {
+  backend "azurerm" {}
+}

--- a/infra-ai-hub/stacks/vllm/locals.tf
+++ b/infra-ai-hub/stacks/vllm/locals.tf
@@ -1,4 +1,5 @@
 locals {
-  vllm_config  = try(var.shared_config.vllm, {})
-  vllm_enabled = try(local.vllm_config.enabled, false)
+  vllm_config        = try(var.shared_config.vllm, {})
+  vllm_enabled       = try(local.vllm_config.enabled, false)
+  use_azureml_source = local.vllm_enabled && try(local.vllm_config.model_source, "huggingface") == "azureml_registry"
 }

--- a/infra-ai-hub/stacks/vllm/locals.tf
+++ b/infra-ai-hub/stacks/vllm/locals.tf
@@ -1,5 +1,4 @@
 locals {
-  vllm_config        = try(var.shared_config.vllm, {})
-  vllm_enabled       = try(local.vllm_config.enabled, false)
-  use_azureml_source = local.vllm_enabled && try(local.vllm_config.model_source, "huggingface") == "azureml_registry"
+  vllm_config  = try(var.shared_config.vllm, {})
+  vllm_enabled = try(local.vllm_config.enabled, false)
 }

--- a/infra-ai-hub/stacks/vllm/locals.tf
+++ b/infra-ai-hub/stacks/vllm/locals.tf
@@ -1,0 +1,4 @@
+locals {
+  vllm_config  = try(var.shared_config.vllm, {})
+  vllm_enabled = try(local.vllm_config.enabled, false)
+}

--- a/infra-ai-hub/stacks/vllm/main.tf
+++ b/infra-ai-hub/stacks/vllm/main.tf
@@ -59,17 +59,3 @@ module "vllm_service" {
   wait_for_private_endpoint_dns_zone_group = try(local.vllm_config.wait_for_private_endpoint_dns_zone_group, false)
 }
 
-# Grants the module's user-assigned identity permission to download model assets from
-# the AzureML registry. Assigned at the registry scope so the identity can list and
-# download any model version registered there. The role assignment must exist before the
-# Container App's init container first runs; creating the identity in the module and the
-# role assignment here (in the stack) ensures the correct sequencing — the module output
-# is only available after the identity resource is created, guaranteeing the assignment
-# happens before the Container App is provisioned.
-resource "azurerm_role_assignment" "azureml_registry_user" {
-  count = local.use_azureml_source ? 1 : 0
-
-  scope                = local.vllm_config.azureml_registry.registry_resource_id
-  role_definition_name = "AzureML Registry User"
-  principal_id         = module.vllm_service[0].azureml_downloader_principal_id
-}

--- a/infra-ai-hub/stacks/vllm/main.tf
+++ b/infra-ai-hub/stacks/vllm/main.tf
@@ -39,6 +39,8 @@ module "vllm_service" {
   model_id               = try(local.vllm_config.model_id, "google/gemma-4-31B-it")
   image                  = try(local.vllm_config.image, "vllm/vllm-openai:latest")
   offline_mode           = try(local.vllm_config.offline_mode, false)
+  model_source           = try(local.vllm_config.model_source, "huggingface")
+  azureml_registry       = try(local.vllm_config.azureml_registry, null)
   quantization           = try(local.vllm_config.quantization, null)
   max_model_len          = try(local.vllm_config.max_model_len, 32768)
   gpu_memory_utilization = try(local.vllm_config.gpu_memory_utilization, 0.9)
@@ -55,4 +57,19 @@ module "vllm_service" {
 
   private_endpoint_dns_wait                = try(var.shared_config.private_endpoint_dns_wait, {})
   wait_for_private_endpoint_dns_zone_group = try(local.vllm_config.wait_for_private_endpoint_dns_zone_group, false)
+}
+
+# Grants the module's user-assigned identity permission to download model assets from
+# the AzureML registry. Assigned at the registry scope so the identity can list and
+# download any model version registered there. The role assignment must exist before the
+# Container App's init container first runs; creating the identity in the module and the
+# role assignment here (in the stack) ensures the correct sequencing — the module output
+# is only available after the identity resource is created, guaranteeing the assignment
+# happens before the Container App is provisioned.
+resource "azurerm_role_assignment" "azureml_registry_user" {
+  count = local.use_azureml_source ? 1 : 0
+
+  scope                = local.vllm_config.azureml_registry.registry_resource_id
+  role_definition_name = "AzureML Registry User"
+  principal_id         = module.vllm_service[0].azureml_downloader_principal_id
 }

--- a/infra-ai-hub/stacks/vllm/main.tf
+++ b/infra-ai-hub/stacks/vllm/main.tf
@@ -38,7 +38,7 @@ module "vllm_service" {
 
   model_id               = try(local.vllm_config.model_id, "google/gemma-4-31B-it")
   image                  = try(local.vllm_config.image, "vllm/vllm-openai:latest")
-  offline_mode           = try(local.vllm_config.offline_mode, false)
+  offline_mode           = try(local.vllm_config.offline_mode, true)
   model_source           = try(local.vllm_config.model_source, "huggingface")
   azureml_registry       = try(local.vllm_config.azureml_registry, null)
   quantization           = try(local.vllm_config.quantization, null)

--- a/infra-ai-hub/stacks/vllm/main.tf
+++ b/infra-ai-hub/stacks/vllm/main.tf
@@ -1,0 +1,58 @@
+data "terraform_remote_state" "shared" {
+  backend = "azurerm"
+
+  config = {
+    resource_group_name  = var.backend_resource_group
+    storage_account_name = var.backend_storage_account
+    container_name       = var.backend_container_name
+    key                  = "ai-services-hub/${var.app_env}/shared.tfstate"
+    subscription_id      = var.subscription_id
+    tenant_id            = var.tenant_id
+    client_id            = var.client_id
+    use_oidc             = var.use_oidc
+  }
+}
+
+# Hugging Face token from hub Key Vault (only resolved when a secret name is configured).
+# Set shared_config.vllm.huggingface_secret_name to the Key Vault secret name that holds
+# the token. Omit to deploy without a token (suitable for ungated public models).
+data "azurerm_key_vault_secret" "huggingface_token" {
+  count        = local.vllm_enabled && try(local.vllm_config.huggingface_secret_name, "") != "" ? 1 : 0
+  name         = local.vllm_config.huggingface_secret_name
+  key_vault_id = data.terraform_remote_state.shared.outputs.hub_key_vault_id
+}
+
+module "vllm_service" {
+  source = "../../modules/vllm-service"
+  count  = local.vllm_enabled ? 1 : 0
+
+  app_name            = "${var.app_name}-${var.app_env}"
+  resource_group_name = data.terraform_remote_state.shared.outputs.resource_group_name
+  location            = var.location
+  common_tags         = var.common_tags
+  scripts_dir         = "${path.root}/../../scripts"
+
+  infrastructure_subnet_id   = data.terraform_remote_state.shared.outputs.vllm_aca_subnet_id
+  private_endpoint_subnet_id = data.terraform_remote_state.shared.outputs.private_endpoint_subnet_id
+  log_analytics_workspace_id = data.terraform_remote_state.shared.outputs.log_analytics_workspace_id
+
+  model_id               = try(local.vllm_config.model_id, "google/gemma-4-31B-it")
+  image                  = try(local.vllm_config.image, "vllm/vllm-openai:latest")
+  offline_mode           = try(local.vllm_config.offline_mode, false)
+  quantization           = try(local.vllm_config.quantization, null)
+  max_model_len          = try(local.vllm_config.max_model_len, 32768)
+  gpu_memory_utilization = try(local.vllm_config.gpu_memory_utilization, 0.9)
+  workload_profile_type  = try(local.vllm_config.workload_profile_type, "Consumption-GPU-NC24-A100")
+  registry_sku           = try(local.vllm_config.registry_sku, "Basic")
+
+  # scale-to-zero by default; GPU cold-start for Gemma 4 31B is 5-10 minutes
+  min_replicas = try(local.vllm_config.min_replicas, 0)
+  max_replicas = try(local.vllm_config.max_replicas, 1)
+
+  model_cache_share_quota_gb = try(local.vllm_config.model_cache_share_quota_gb, 64)
+
+  huggingface_token = length(data.azurerm_key_vault_secret.huggingface_token) > 0 ? data.azurerm_key_vault_secret.huggingface_token[0].value : ""
+
+  private_endpoint_dns_wait                = try(var.shared_config.private_endpoint_dns_wait, {})
+  wait_for_private_endpoint_dns_zone_group = try(local.vllm_config.wait_for_private_endpoint_dns_zone_group, false)
+}

--- a/infra-ai-hub/stacks/vllm/outputs.tf
+++ b/infra-ai-hub/stacks/vllm/outputs.tf
@@ -1,0 +1,11 @@
+output "vllm_service" {
+  description = "vLLM Container App service details (null when not deployed)"
+  value = length(module.vllm_service) > 0 ? {
+    container_app_fqdn    = module.vllm_service[0].container_app_fqdn
+    endpoint              = module.vllm_service[0].endpoint
+    openai_endpoint       = module.vllm_service[0].openai_endpoint
+    model_id              = module.vllm_service[0].model_id
+    max_model_len         = module.vllm_service[0].max_model_len
+    workload_profile_type = module.vllm_service[0].workload_profile_type
+  } : null
+}

--- a/infra-ai-hub/stacks/vllm/providers.tf
+++ b/infra-ai-hub/stacks/vllm/providers.tf
@@ -1,0 +1,35 @@
+terraform {
+  required_version = ">= 1.12.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 4.57.0, < 5.0.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 3.2.4, < 4.0.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.7.2, < 4.0.0"
+    }
+    time = {
+      source  = "hashicorp/time"
+      version = ">= 0.13.1, < 1.0.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+
+  subscription_id = var.subscription_id
+  tenant_id       = var.tenant_id
+  use_oidc        = var.use_oidc
+  client_id       = var.client_id
+}

--- a/infra-ai-hub/stacks/vllm/variables.tf
+++ b/infra-ai-hub/stacks/vllm/variables.tf
@@ -1,0 +1,65 @@
+variable "app_env" {
+  description = "Deployment environment (dev, test, prod)"
+  type        = string
+}
+
+variable "app_name" {
+  description = "Application / workload name prefix"
+  type        = string
+}
+
+variable "location" {
+  description = "Azure region"
+  type        = string
+}
+
+variable "common_tags" {
+  description = "Tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}
+
+variable "subscription_id" {
+  description = "Azure subscription ID"
+  type        = string
+  sensitive   = true
+}
+
+variable "tenant_id" {
+  description = "Azure AD tenant ID"
+  type        = string
+  sensitive   = true
+}
+
+variable "client_id" {
+  description = "Service principal / managed identity client ID used for OIDC auth"
+  type        = string
+  sensitive   = true
+}
+
+variable "use_oidc" {
+  description = "Use OIDC federated credentials for provider authentication"
+  type        = bool
+  default     = true
+}
+
+variable "shared_config" {
+  description = "Shared configuration object (maps to environment tfvars shared_config block)"
+  type        = any
+}
+
+variable "backend_resource_group" {
+  description = "Resource group containing the Terraform state storage account"
+  type        = string
+}
+
+variable "backend_storage_account" {
+  description = "Storage account name for Terraform remote state"
+  type        = string
+}
+
+variable "backend_container_name" {
+  description = "Blob container name for Terraform remote state"
+  type        = string
+  default     = "tfstate"
+}

--- a/initial-setup/README.md
+++ b/initial-setup/README.md
@@ -111,11 +111,11 @@ If your system uses a different package manager, the script will exit with a lin
 
 # Application Configuration
 app_env  = "tools"
-app_name = "ai-hub-deploy-utils"
+app_name = "myapp"
 
 # Azure Resource Configuration
 location            = "Canada Central"
-resource_group_name = "ai-hub-deploy-utils-tools"
+resource_group_name = "myapp-tools"
 # Virtual Network Configuration (existing VNet from platform team)
 vnet_name                = "$licenseplate-tools-vwan-spoke" # Set via TF_VAR_vnet_name or GitHub secret
 vnet_resource_group_name = "$licenseplate-tools-networking" # Set via TF_VAR_vnet_resource_group_name or GitHub secret
@@ -123,9 +123,11 @@ vnet_address_space       = "$address-space"          # Set via TF_VAR_vnet_addre
 
 # Common Tags
 common_tags = {
-  Environment = "tools"
-  Project     = "ai-hub-deploy-utils"
-  ManagedBy   = "Terraform"
+  environment = "tools"
+  app_env     = "tools"
+  repo_name   = "ai-hub-tracking"
+  project     = "myapp"
+  managed_by  = "Terraform"
 }
 
 
@@ -143,8 +145,9 @@ github_organization             = "bcgov"                                    # S
 github_repository               = "ai-hub-tracking"                          # Set via TF_VAR_github_repository
 github_runner_pat               = "$github_pat" # Set via TF_VAR_github_runner_pat (sensitive)
 ```
----
 
+When you reuse an existing remote state, keep `app_name`, `resource_group_name`, tags, and feature toggles aligned with the already-deployed environment. Changing those values against an existing backend can turn a targeted apply into a broad replacement plan.
+---
 ## Manual Terraform Deployment
 
 If you skipped the infrastructure deployment during setup, or need to run it separately:
@@ -197,7 +200,7 @@ initial-setup/infra/
     ├── bastion/            # Azure Bastion host
     ├── github-runners-aca/ # Self-hosted GitHub runners
     ├── jumpbox/            # Development VM
-    ├── azure-proxy/            # The Secure tunnel deployment using chisel
+    ├── azure-proxy/        # The secure tunnel deployment using chisel
     └── network/            # Subnets and NSGs
 ```
 

--- a/initial-setup/infra/variables.tf
+++ b/initial-setup/infra/variables.tf
@@ -174,6 +174,15 @@ variable "enable_jumpbox" {
   default     = false
 }
 
+variable "private_endpoint_dns_wait" {
+  description = "Configuration for waiting on policy-managed private endpoint DNS zone groups"
+  type = object({
+    timeout       = optional(string, "15m")
+    poll_interval = optional(string, "30s")
+  })
+  default = {}
+}
+
 variable "enable_entra_login" {
   description = "Enable Microsoft Entra ID (AAD) SSH login on the jumpbox VM"
   type        = bool

--- a/tenant-onboarding-portal/infra/locals.tf
+++ b/tenant-onboarding-portal/infra/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  resource_group_name = var.app_name_override != "" ? "${var.app_name_override}-rg" : "ai-hub-portal-rg"
+  resource_group_name       = var.app_name_override != "" ? "${var.app_name_override}-rg" : "ai-hub-portal-rg"
   app_service_plan_name     = var.app_name_override != "" ? "${var.app_name_override}-asp" : "ai-hub-portal-asp"
   portal_node_major_version = trimspace(file("${path.module}/../.node-version"))
   portal_node_version       = var.node_version != "" ? var.node_version : "${local.portal_node_major_version}-lts"

--- a/tests/integration/src/ai_hub_integration/config.py
+++ b/tests/integration/src/ai_hub_integration/config.py
@@ -296,6 +296,25 @@ class IntegrationConfig:
         """Return tenant models that are valid on the deployments chat route."""
         return filter_deployments_chat_models(self.get_tenant_models(tenant))
 
+    def get_tenant_vllm_models(self, tenant: str) -> list[str]:
+        """Return vLLM model IDs configured for a tenant, from tfvars or VLLM_MODEL_ID env var."""
+        env_model = os.getenv("VLLM_MODEL_ID")
+        if env_model and os.getenv("VLLM_ENABLED", "").lower() in {"1", "true", "yes"}:
+            return [env_model]
+
+        tenant_file = self.infra_dir / "params" / self.environment / "tenants" / tenant / "tenant.tfvars"
+        if not tenant_file.exists():
+            return []
+
+        text = tenant_file.read_text(encoding="utf-8")
+        vllm_block = _extract_named_block(text, "vllm")
+        if not vllm_block:
+            return []
+        enabled_match = re.search(r"^\s*enabled\s*=\s*(true|false)\b", vllm_block, flags=re.MULTILINE)
+        if not enabled_match or enabled_match.group(1).lower() != "true":
+            return []
+        return re.findall(r'model_id\s*=\s*"([^"]+)"', vllm_block)
+
     def is_apim_key_rotation_enabled(self) -> bool:
         """Determine whether APIM key rotation is enabled in shared tfvars."""
         shared_tfvars = self.infra_dir / "params" / self.environment / "shared.tfvars"

--- a/tests/integration/tests/test_vllm_chat_completions.py
+++ b/tests/integration/tests/test_vllm_chat_completions.py
@@ -118,6 +118,7 @@ def test_vllm_streaming_returns_sse_chunks_with_usage(
     assert usage_chunks, "Expected usage chunk in SSE stream (APIM injects stream_options.include_usage)"
     usage = usage_chunks[0]["usage"]
     assert usage.get("prompt_tokens", 0) > 0
+    assert usage.get("completion_tokens", 0) > 0
 
 
 def test_vllm_rate_limit_headers_present(client: ApimClient, integration_config: IntegrationConfig) -> None:

--- a/tests/integration/tests/test_vllm_chat_completions.py
+++ b/tests/integration/tests/test_vllm_chat_completions.py
@@ -1,0 +1,187 @@
+"""Integration tests for vLLM-backed open-source model routing via APIM.
+
+These tests verify that a tenant with vLLM enabled can reach a GPU-backed
+open-source model through the same /openai/v1 base URL as Foundry, with the
+backend determined solely by the `model` field in the request body.
+
+All tests are skipped when vLLM is not enabled for the primary tenant (i.e.
+VLLM_MODEL_ID env var is absent and no vllm block is present in tenant.tfvars).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from ai_hub_integration.client import ApimClient
+from ai_hub_integration.config import IntegrationConfig
+
+from .support import PRIMARY_TENANT, assert_status, require_key, response_json
+
+pytestmark = [pytest.mark.live]
+
+VLLM_TENANT = PRIMARY_TENANT
+
+
+def _vllm_model(config: IntegrationConfig) -> str:
+    """Return the first configured vLLM model ID for the test tenant, or skip."""
+    models = config.get_tenant_vllm_models(VLLM_TENANT)
+    if not models:
+        pytest.skip(
+            f"vLLM not enabled for tenant '{VLLM_TENANT}' — "
+            "set VLLM_ENABLED=true and VLLM_MODEL_ID in the environment or enable vllm in tenant.tfvars"
+        )
+    return models[0]
+
+
+def _chat_body(model_id: str, message: str, max_tokens: int = 30, *, stream: bool = False) -> dict:
+    return {
+        "model": model_id,
+        "messages": [{"role": "user", "content": message}],
+        "max_tokens": max_tokens,
+        "temperature": 0.1,
+        **({"stream": True} if stream else {}),
+    }
+
+
+def test_vllm_chat_completion_returns_200(client: ApimClient, integration_config: IntegrationConfig) -> None:
+    """Verify that a vLLM model ID routed through /openai/v1 returns HTTP 200."""
+    require_key(integration_config, VLLM_TENANT)
+    model_id = _vllm_model(integration_config)
+
+    response = client.chat_completion_v1(VLLM_TENANT, model_id, "Say hello in one word", 30)
+
+    assert_status(response, 200)
+
+
+def test_vllm_response_contains_valid_choices(client: ApimClient, integration_config: IntegrationConfig) -> None:
+    """Verify that vLLM responses include a populated choices array with message content."""
+    require_key(integration_config, VLLM_TENANT)
+    model_id = _vllm_model(integration_config)
+
+    response = client.chat_completion_v1(VLLM_TENANT, model_id, "What is 2+2?", 30)
+    payload = response_json(response)
+
+    assert_status(response, 200)
+    assert payload.get("choices"), "Expected non-empty choices array"
+    assert payload["choices"][0]["message"]["content"], "Expected non-empty message content"
+
+
+def test_vllm_model_id_not_rewritten_to_tenant_prefix(
+    client: ApimClient, integration_config: IntegrationConfig
+) -> None:
+    """Verify that vLLM model IDs are forwarded unchanged (not prefixed with tenant name).
+
+    Foundry deployment names are rewritten to '{tenant}-{name}' by APIM.
+    vLLM model IDs (e.g. 'google/gemma-4-31B-it') must NOT be rewritten.
+    """
+    require_key(integration_config, VLLM_TENANT)
+    model_id = _vllm_model(integration_config)
+
+    response = client.chat_completion_v1(VLLM_TENANT, model_id, "Say hello", 30)
+    payload = response_json(response)
+
+    assert_status(response, 200)
+    returned_model = payload.get("model", "")
+    assert VLLM_TENANT not in returned_model, (
+        f"vLLM model was prefixed with tenant name: '{returned_model}' — "
+        "APIM model-body rewrite should not fire on vLLM requests"
+    )
+
+
+def test_vllm_streaming_returns_sse_chunks_with_usage(
+    client: ApimClient, integration_config: IntegrationConfig
+) -> None:
+    """Verify that vLLM streaming produces valid SSE chunks including a usage chunk."""
+    require_key(integration_config, VLLM_TENANT)
+    model_id = _vllm_model(integration_config)
+
+    response = client.request(
+        "POST",
+        VLLM_TENANT,
+        "/openai/v1/chat/completions",
+        json_body=_chat_body(model_id, "Say hello", stream=True),
+        retry=True,
+    )
+
+    assert_status(response, 200)
+    lines = [ln.strip() for ln in response.text.replace("\r", "").splitlines() if ln.strip()]
+    data_lines = [ln for ln in lines if ln.startswith("data: ")]
+
+    assert any(ln == "data: [DONE]" for ln in data_lines), "Missing SSE [DONE] terminator"
+    chunks = [json.loads(ln.removeprefix("data: ")) for ln in data_lines if ln.startswith("data: {")]
+    chat_chunks = [c for c in chunks if c.get("object") == "chat.completion.chunk"]
+    assert chat_chunks, "No chat.completion.chunk objects in SSE stream"
+
+    usage_chunks = [c for c in chunks if c.get("usage") is not None]
+    assert usage_chunks, "Expected usage chunk in SSE stream (APIM injects stream_options.include_usage)"
+    usage = usage_chunks[0]["usage"]
+    assert usage.get("prompt_tokens", 0) > 0
+
+
+def test_vllm_rate_limit_headers_present(client: ApimClient, integration_config: IntegrationConfig) -> None:
+    """Verify that vLLM responses include APIM rate-limit headers."""
+    require_key(integration_config, VLLM_TENANT)
+    model_id = _vllm_model(integration_config)
+
+    response = client.request(
+        "POST",
+        VLLM_TENANT,
+        "/openai/v1/chat/completions",
+        json_body=_chat_body(model_id, "Hi", 10),
+        retry=True,
+    )
+
+    assert_status(response, 200)
+    assert "x-ratelimit-limit-tokens" in response.headers, "Missing x-ratelimit-limit-tokens header"
+    assert "x-ratelimit-remaining-tokens" in response.headers, "Missing x-ratelimit-remaining-tokens header"
+
+
+def test_vllm_model_id_via_deployments_path_returns_400(
+    client: ApimClient, integration_config: IntegrationConfig
+) -> None:
+    """Verify that using a vLLM model ID in a /deployments/ URL returns 400.
+
+    vLLM model IDs contain '/' (e.g. 'google/gemma-4-31B-it') which cannot be
+    expressed as a deployment-URL path segment. APIM should reject with 400.
+    """
+    require_key(integration_config, VLLM_TENANT)
+    model_id = _vllm_model(integration_config)
+
+    if "/" not in model_id:
+        pytest.skip(f"Model ID '{model_id}' has no slash — deployments-path rejection test is not applicable")
+
+    # Encode slashes as path segments — APIM routing should reject this
+    deployment_path = (
+        f"/openai/deployments/{model_id}/chat/completions?api-version={integration_config.openai_api_version}"
+    )
+    response = client.request(
+        "POST",
+        VLLM_TENANT,
+        deployment_path,
+        json_body={"messages": [{"role": "user", "content": "hello"}], "max_tokens": 10},
+    )
+
+    assert response.status_code == 400, (
+        f"Expected 400 for vLLM model ID in /deployments/ URL, got {response.status_code}. "
+        "APIM should reject slash-containing model IDs in /deployments/ path with 400 UnsupportedRoute."
+    )
+
+
+def test_vllm_no_auth_headers_forwarded(client: ApimClient, integration_config: IntegrationConfig) -> None:
+    """Verify that a successful vLLM response indicates APIM did not fail on missing Azure MSI token.
+
+    The vLLM backend is private and has no authentication requirement — APIM must
+    strip both Authorization and api-key before forwarding. A 200 response from
+    vLLM confirms the headers were stripped (if they were forwarded, vLLM would
+    either ignore or reject them, but more importantly APIM would not fail to get
+    an MSI token since none is requested).
+    """
+    require_key(integration_config, VLLM_TENANT)
+    model_id = _vllm_model(integration_config)
+
+    response = client.chat_completion_v1(VLLM_TENANT, model_id, "Say hi", 10)
+
+    # A 200 confirms the vLLM path executed without MSI token acquisition errors
+    assert_status(response, 200)


### PR DESCRIPTION


<!-- ai-hub-infra-changes -->
## AI Hub Infra Changes

**Summary:** 2 to add, 20 to change, 0 to destroy (across 4 stack(s))

<details><summary>Show plan details</summary>

```hcl
Terraform will perform the following actions:

  # module.foundry_project["ai-hub-admin"].azapi_resource.rai_policy["gpt-5.1-chat"] will be updated in-place
  ~ resource "azapi_resource" "rai_policy" {
      ~ body                      = {
          ~ properties = {
              ~ contentFilters = [
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Violence" -> "violence"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Violence" -> "violence"
                        # (4 unchanged attributes hidden)
                    },
                ]
                # (2 unchanged attributes hidden)
            }
        }
        id                        = "/subscriptions/****/resourceGroups/ai-services-hub-test/providers/Microsoft.CognitiveServices/accounts/ai-services-hub-test-foundry/raiPolicies/ai-hub-admin-gpt-5-1-chat-filter"
        name                      = "ai-hub-admin-gpt-5-1-chat-filter"
      ~ output                    = {} -> (known after apply)
        # (7 unchanged attributes hidden)
    }

  # module.foundry_project["gcpe-media-monitoring"].azapi_resource.rai_policy["gpt-4.1"] will be updated in-place
  ~ resource "azapi_resource" "rai_policy" {
      ~ body                      = {
          ~ properties = {
              ~ contentFilters = [
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Violence" -> "violence"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Violence" -> "violence"
                        # (4 unchanged attributes hidden)
                    },
                ]
                # (2 unchanged attributes hidden)
            }
        }
        id                        = "/subscriptions/****/resourceGroups/ai-services-hub-test/providers/Microsoft.CognitiveServices/accounts/ai-services-hub-test-foundry/raiPolicies/gcpe-media-monitoring-gpt-4-1-filter"
        name                      = "gcpe-media-monitoring-gpt-4-1-filter"
      ~ output                    = {} -> (known after apply)
        # (7 unchanged attributes hidden)
    }

  # module.foundry_project["gcpe-media-monitoring"].azapi_resource.rai_policy["gpt-4.1-mini"] will be updated in-place
  ~ resource "azapi_resource" "rai_policy" {
      ~ body                      = {
          ~ properties = {
              ~ contentFilters = [
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Violence" -> "violence"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Violence" -> "violence"
                        # (4 unchanged attributes hidden)
                    },
                ]
                # (2 unchanged attributes hidden)
            }
        }
        id                        = "/subscriptions/****/resourceGroups/ai-services-hub-test/providers/Microsoft.CognitiveServices/accounts/ai-services-hub-test-foundry/raiPolicies/gcpe-media-monitoring-gpt-4-1-mini-filter"
        name                      = "gcpe-media-monitoring-gpt-4-1-mini-filter"
      ~ output                    = {} -> (known after apply)
        # (7 unchanged attributes hidden)
    }

  # module.foundry_project["gcpe-media-monitoring"].azapi_resource.rai_policy["gpt-4.1-nano"] will be updated in-place
  ~ resource "azapi_resource" "rai_policy" {
      ~ body                      = {
          ~ properties = {
              ~ contentFilters = [
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Violence" -> "violence"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Violence" -> "violence"
                        # (4 unchanged attributes hidden)
                    },
                ]
                # (2 unchanged attributes hidden)
            }
        }
        id                        = "/subscriptions/****/resourceGroups/ai-services-hub-test/providers/Microsoft.CognitiveServices/accounts/ai-services-hub-test-foundry/raiPolicies/gcpe-media-monitoring-gpt-4-1-nano-filter"
        name                      = "gcpe-media-monitoring-gpt-4-1-nano-filter"
      ~ output                    = {} -> (known after apply)
        # (7 unchanged attributes hidden)
    }

  # module.foundry_project["gcpe-media-monitoring"].azapi_resource.rai_policy["gpt-4o"] will be updated in-place
  ~ resource "azapi_resource" "rai_policy" {
      ~ body                      = {
          ~ properties = {
              ~ contentFilters = [
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Violence" -> "violence"
```

</details>

---
_Updated by CI — plan against `test` environment (run [#358](https://github.com/bcgov/ai-hub-tracking/actions/runs/24323974846)) at 2026-04-13 03:22:30 UTC._
<!-- /ai-hub-infra-changes -->