### PR TITLE
chore

### DIFF
--- a/infra-ai-hub/modules/foundry-project/main.tf
+++ b/infra-ai-hub/modules/foundry-project/main.tf
@@ -271,6 +271,21 @@ resource "azapi_resource" "ai_model_deployment" {
 
   schema_validation_enabled = false
 
+
+  # THIS IS A TEMP Change, to push the flags of PII redaction, 
+  # till we sort out MODEL deccommising stratergy. 
+  # Once a deployment exists, do not re-push its body on subsequent applies.
+  # Deprecated models (e.g. gpt-5.1-chat) reject any update PUT with
+  # ServiceModelDeprecated, which would otherwise break the CI/CD pipeline.
+  # Azure manages version upgrades server-side via versionUpgradeOption, so
+  # ignoring body changes here is safe; capacity/RAI/version changes to an
+  # existing deployment must be made out-of-band or by recreating it.
+  # NOTE: lifecycle blocks are static and cannot be scoped to a single
+  # for_each instance, so this applies to all model deployments.
+  lifecycle {
+    ignore_changes = [body]
+  }
+
   # Serialize after project and RAI policy creation to avoid ETag conflicts
   depends_on = [
     azapi_resource.project,

--- a/infra-ai-hub/params/dev/tenants/ai-hub-admin/tenant.tfvars
+++ b/infra-ai-hub/params/dev/tenants/ai-hub-admin/tenant.tfvars
@@ -344,6 +344,7 @@ tenant = {
     pii_redaction = {
       enabled     = false # Redact emails, phone numbers, addresses, etc.
       fail_closed = false # Fail-open: allow requests through if PII service fails
+      excluded_categories = []
     }
     usage_logging = {
       enabled = true # Log AI model token usage

--- a/infra-ai-hub/params/dev/tenants/bc-archeology-portal/tenant.tfvars
+++ b/infra-ai-hub/params/dev/tenants/bc-archeology-portal/tenant.tfvars
@@ -199,6 +199,7 @@ tenant = {
     pii_redaction = {
       enabled     = true
       fail_closed = false
+      excluded_categories = []
     }
     usage_logging = {
       enabled = true

--- a/infra-ai-hub/params/dev/tenants/gcpe-media-monitoring/tenant.tfvars
+++ b/infra-ai-hub/params/dev/tenants/gcpe-media-monitoring/tenant.tfvars
@@ -367,6 +367,7 @@ tenant = {
     pii_redaction = {
       enabled     = false # Redact emails, phone numbers, addresses, etc.
       fail_closed = false # Fail-open: allow requests through if PII service fails
+      excluded_categories = []
     }
     usage_logging = {
       enabled = true # Log AI model token usage

--- a/infra-ai-hub/params/dev/tenants/nr-dap-fish-wildlife/tenant.tfvars
+++ b/infra-ai-hub/params/dev/tenants/nr-dap-fish-wildlife/tenant.tfvars
@@ -244,6 +244,7 @@ tenant = {
     pii_redaction = {
       enabled     = false # Redact emails, phone numbers, addresses, etc.
       fail_closed = false # Fail-open: allow requests through if PII service fails
+      excluded_categories = []
     }
     usage_logging = {
       enabled = true # Log AI model token usage

--- a/infra-ai-hub/params/dev/tenants/sdpr-invoice-automation/tenant.tfvars
+++ b/infra-ai-hub/params/dev/tenants/sdpr-invoice-automation/tenant.tfvars
@@ -241,6 +241,7 @@ tenant = {
     pii_redaction = {
       enabled     = true
       fail_closed = true # Block requests if PII service fails (not applicable when disabled)
+      excluded_categories = []
     }
     usage_logging = {
       enabled = true

--- a/infra-ai-hub/params/dev/tenants/wlrs-water-form-assistant/tenant.tfvars
+++ b/infra-ai-hub/params/dev/tenants/wlrs-water-form-assistant/tenant.tfvars
@@ -243,7 +243,7 @@ tenant = {
       tokens_per_minute = 1000
     }
     pii_redaction = {
-      enabled     = false  # Redact emails, phone numbers, addresses, etc.
+      enabled = true  # Redact emails, phone numbers, addresses, etc.
       fail_closed = false # Fail-open: allow requests through if PII service fails
     }
     usage_logging = {

--- a/infra-ai-hub/params/dev/tenants/wlrs-water-form-assistant/tenant.tfvars
+++ b/infra-ai-hub/params/dev/tenants/wlrs-water-form-assistant/tenant.tfvars
@@ -245,6 +245,7 @@ tenant = {
     pii_redaction = {
       enabled = true  # Redact emails, phone numbers, addresses, etc.
       fail_closed = false # Fail-open: allow requests through if PII service fails
+      excluded_categories = ["PersonType", "URL"] # Do not redact these PII categories for WLRS
     }
     usage_logging = {
       enabled = true # Log AI model token usage

--- a/infra-ai-hub/params/test/tenants/ai-hub-admin/tenant.tfvars
+++ b/infra-ai-hub/params/test/tenants/ai-hub-admin/tenant.tfvars
@@ -344,6 +344,7 @@ tenant = {
     pii_redaction = {
       enabled     = false # Redact emails, phone numbers, addresses, etc.
       fail_closed = false # Fail-open: allow requests through if PII service fails
+      excluded_categories = []
     }
     usage_logging = {
       enabled = true # Log AI model token usage

--- a/infra-ai-hub/params/test/tenants/bc-archeology-portal/tenant.tfvars
+++ b/infra-ai-hub/params/test/tenants/bc-archeology-portal/tenant.tfvars
@@ -199,6 +199,7 @@ tenant = {
     pii_redaction = {
       enabled     = true
       fail_closed = false
+      excluded_categories = []
     }
     usage_logging = {
       enabled = true

--- a/infra-ai-hub/params/test/tenants/gcpe-media-monitoring/tenant.tfvars
+++ b/infra-ai-hub/params/test/tenants/gcpe-media-monitoring/tenant.tfvars
@@ -385,6 +385,7 @@ tenant = {
     pii_redaction = {
       enabled     = false # Redact emails, phone numbers, addresses, etc.
       fail_closed = false # Fail-open: allow requests through if PII service fails
+      excluded_categories = []
     }
     usage_logging = {
       enabled = true # Log AI model token usage

--- a/infra-ai-hub/params/test/tenants/nr-dap-fish-wildlife/tenant.tfvars
+++ b/infra-ai-hub/params/test/tenants/nr-dap-fish-wildlife/tenant.tfvars
@@ -262,6 +262,7 @@ tenant = {
     pii_redaction = {
       enabled     = false # Redact emails, phone numbers, addresses, etc.
       fail_closed = false # Fail-open: allow requests through if PII service fails
+      excluded_categories = []
     }
     usage_logging = {
       enabled = true # Log AI model token usage

--- a/infra-ai-hub/params/test/tenants/sdpr-invoice-automation/tenant.tfvars
+++ b/infra-ai-hub/params/test/tenants/sdpr-invoice-automation/tenant.tfvars
@@ -259,6 +259,7 @@ tenant = {
     pii_redaction = {
       enabled     = true
       fail_closed = true # Block requests if PII service fails (not applicable when disabled)
+      excluded_categories = []
     }
     usage_logging = {
       enabled = true

--- a/infra-ai-hub/params/test/tenants/wlrs-water-form-assistant/tenant.tfvars
+++ b/infra-ai-hub/params/test/tenants/wlrs-water-form-assistant/tenant.tfvars
@@ -273,6 +273,7 @@ tenant = {
     pii_redaction = {
       enabled = true  # Redact emails, phone numbers, addresses, etc.
       fail_closed = false # Fail-open: allow requests through if PII service fails
+      excluded_categories = ["PersonType", "URL"] # Do not redact these PII categories for WLRS
     }
     usage_logging = {
       enabled = true # Log AI model token usage

--- a/infra-ai-hub/params/test/tenants/wlrs-water-form-assistant/tenant.tfvars
+++ b/infra-ai-hub/params/test/tenants/wlrs-water-form-assistant/tenant.tfvars
@@ -271,7 +271,7 @@ tenant = {
       tokens_per_minute = 1000
     }
     pii_redaction = {
-      enabled     = false  # Redact emails, phone numbers, addresses, etc.
+      enabled = true  # Redact emails, phone numbers, addresses, etc.
       fail_closed = false # Fail-open: allow requests through if PII service fails
     }
     usage_logging = {

--- a/infra-ai-hub/stacks/apim/locals.tf
+++ b/infra-ai-hub/stacks/apim/locals.tf
@@ -240,7 +240,7 @@ locals {
         usage_logging_enabled          = try(config.apim_policies.usage_logging.enabled, true)
         tracking_dimensions_enabled    = try(config.apim_policies.tracking_dimensions.enabled, true)
         backend_timeout_seconds        = try(config.apim_policies.backend_timeout_seconds, 300)
-        pii_excluded_categories        = try(config.apim_policies.pii_redaction.excluded_categories, [])
+        pii_excluded_categories        = jsonencode(try(config.apim_policies.pii_redaction.excluded_categories, []))
         pii_detection_language         = try(config.apim_policies.pii_redaction.detection_language, "en")
         pii_fail_closed                = try(config.apim_policies.pii_redaction.fail_closed, false)
         pii_scan_roles                 = jsonencode(try(config.apim_policies.pii_redaction.scan_roles, ["user", "assistant", "tool"]))

--- a/infra-ai-hub/stacks/pii-redaction/variables.tf
+++ b/infra-ai-hub/stacks/pii-redaction/variables.tf
@@ -72,5 +72,5 @@ variable "container_image_tag_svc_pii_redaction" {
 variable "language_api_version" {
   description = "Override Language API version string (empty = use config default, typically stable GA version)"
   type        = string
-  default     = "2024-11-01"
+  default     = "2026-05-01"
 }


### PR DESCRIPTION


<!-- ai-hub-infra-changes -->
## AI Hub Infra Changes

**Summary:** 2 to add, 16 to change, 0 to destroy (across 4 stack(s))

<details><summary>Show plan details</summary>

```hcl
Terraform will perform the following actions:

  # module.foundry_project["ai-hub-admin"].azapi_resource.rai_policy["gpt-5.1-chat"] will be updated in-place
  ~ resource "azapi_resource" "rai_policy" {
      ~ body                      = {
          ~ properties = {
              ~ contentFilters = [
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Violence" -> "violence"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Violence" -> "violence"
                        # (4 unchanged attributes hidden)
                    },
                ]
                # (2 unchanged attributes hidden)
            }
        }
        id                        = "/subscriptions/****/resourceGroups/ai-services-hub-test/providers/Microsoft.CognitiveServices/accounts/ai-services-hub-test-foundry/raiPolicies/ai-hub-admin-gpt-5-1-chat-filter"
        name                      = "ai-hub-admin-gpt-5-1-chat-filter"
      ~ output                    = {} -> (known after apply)
        # (7 unchanged attributes hidden)
    }

  # module.foundry_project["gcpe-media-monitoring"].azapi_resource.rai_policy["gpt-4.1"] will be updated in-place
  ~ resource "azapi_resource" "rai_policy" {
      ~ body                      = {
          ~ properties = {
              ~ contentFilters = [
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Violence" -> "violence"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Violence" -> "violence"
                        # (4 unchanged attributes hidden)
                    },
                ]
                # (2 unchanged attributes hidden)
            }
        }
        id                        = "/subscriptions/****/resourceGroups/ai-services-hub-test/providers/Microsoft.CognitiveServices/accounts/ai-services-hub-test-foundry/raiPolicies/gcpe-media-monitoring-gpt-4-1-filter"
        name                      = "gcpe-media-monitoring-gpt-4-1-filter"
      ~ output                    = {} -> (known after apply)
        # (7 unchanged attributes hidden)
    }

  # module.foundry_project["gcpe-media-monitoring"].azapi_resource.rai_policy["gpt-4.1-mini"] will be updated in-place
  ~ resource "azapi_resource" "rai_policy" {
      ~ body                      = {
          ~ properties = {
              ~ contentFilters = [
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Violence" -> "violence"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Violence" -> "violence"
                        # (4 unchanged attributes hidden)
                    },
                ]
                # (2 unchanged attributes hidden)
            }
        }
        id                        = "/subscriptions/****/resourceGroups/ai-services-hub-test/providers/Microsoft.CognitiveServices/accounts/ai-services-hub-test-foundry/raiPolicies/gcpe-media-monitoring-gpt-4-1-mini-filter"
        name                      = "gcpe-media-monitoring-gpt-4-1-mini-filter"
      ~ output                    = {} -> (known after apply)
        # (7 unchanged attributes hidden)
    }

  # module.foundry_project["gcpe-media-monitoring"].azapi_resource.rai_policy["gpt-4.1-nano"] will be updated in-place
  ~ resource "azapi_resource" "rai_policy" {
      ~ body                      = {
          ~ properties = {
              ~ contentFilters = [
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Violence" -> "violence"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Violence" -> "violence"
                        # (4 unchanged attributes hidden)
                    },
                ]
                # (2 unchanged attributes hidden)
            }
        }
        id                        = "/subscriptions/****/resourceGroups/ai-services-hub-test/providers/Microsoft.CognitiveServices/accounts/ai-services-hub-test-foundry/raiPolicies/gcpe-media-monitoring-gpt-4-1-nano-filter"
        name                      = "gcpe-media-monitoring-gpt-4-1-nano-filter"
      ~ output                    = {} -> (known after apply)
        # (7 unchanged attributes hidden)
    }

  # module.foundry_project["gcpe-media-monitoring"].azapi_resource.rai_policy["gpt-4o"] will be updated in-place
  ~ resource "azapi_resource" "rai_policy" {
      ~ body                      = {
          ~ properties = {
              ~ contentFilters = [
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "selfharm" -> "hate"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Hate" -> "selfharm"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Sexual" -> "sexual"
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      ~ name              = "Violence" -> "violence"
```

</details>

---
_Updated by CI — plan against `test` environment (run [#417](https://github.com/bcgov/ai-hub-tracking/actions/runs/29385799054)) at 2026-07-15 03:16:32 UTC._
<!-- /ai-hub-infra-changes -->