### PR TITLE
feat: ai-common-services-pii-categories exclusion:- organization, loca…

### DIFF
--- a/infra-ai-hub/params/dev/tenants/wlrs-water-form-assistant/tenant.tfvars
+++ b/infra-ai-hub/params/dev/tenants/wlrs-water-form-assistant/tenant.tfvars
@@ -245,7 +245,7 @@ tenant = {
     pii_redaction = {
       enabled = true  # Redact emails, phone numbers, addresses, etc.
       fail_closed = false # Fail-open: allow requests through if PII service fails
-      excluded_categories = ["PersonType", "URL"] # Do not redact these PII categories for WLRS
+      excluded_categories = ["PersonType", "URL","Organization","Location","City"] # Do not redact these PII categories for WLRS
     }
     usage_logging = {
       enabled = true # Log AI model token usage

--- a/infra-ai-hub/params/test/tenants/wlrs-water-form-assistant/tenant.tfvars
+++ b/infra-ai-hub/params/test/tenants/wlrs-water-form-assistant/tenant.tfvars
@@ -273,7 +273,7 @@ tenant = {
     pii_redaction = {
       enabled = true  # Redact emails, phone numbers, addresses, etc.
       fail_closed = false # Fail-open: allow requests through if PII service fails
-      excluded_categories = ["PersonType", "URL"] # Do not redact these PII categories for WLRS
+      excluded_categories = ["PersonType", "URL","Organization","Location","City"] # Do not redact these PII categories for WLRS
     }
     usage_logging = {
       enabled = true # Log AI model token usage


### PR DESCRIPTION
…tion, city

<!-- ai-hub-infra-changes -->
## AI Hub Infra Changes

**Summary:** 2 to add, 18 to change, 0 to destroy (across 5 stack(s))

<details><summary>Show plan details</summary>

```hcl
Terraform will perform the following actions:

  # azurerm_cognitive_account.language_service[0] will be updated in-place
  ~ resource "azurerm_cognitive_account" "language_service" {
        id                                          = "/subscriptions/****/resourceGroups/ai-services-hub-test/providers/Microsoft.CognitiveServices/accounts/ai-services-hub-test-language"
      ~ local_auth_enabled                          = true -> false
        name                                        = "ai-services-hub-test-language"
        tags                                        = {
            "app_env"     = "test"
            "environment" = "test"
            "repo_name"   = "ai-hub-tracking"
        }
        # (19 unchanged attributes hidden)

        # (2 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Warning: Argument is deprecated

  with module.hub_key_vault.azurerm_key_vault.this,
  on .terraform/modules/hub_key_vault/main.tf line 7, in resource "azurerm_key_vault" "this":
   7:   enable_rbac_authorization       = !var.legacy_access_policies_enabled

This property has been renamed to `rbac_authorization_enabled` and will be
removed in v5.0 of the provider

(and 2 more similar warnings elsewhere)

─────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't
guarantee to take exactly these actions if you run "terraform apply" now.
Releasing state lock. This may take a few moments...
2026-08-10T17:31:01Z [SUCCESS] terraform plan (shared) (attempt 1/5) completed successfully
2026-08-10T17:31:03Z [INFO] Running 7 tenants in parallel
2026-08-10T17:31:03Z [INFO] Starting terraform init (tenant:ai-hub-admin)
Initializing the backend...

Successfully configured the backend "azurerm"! Terraform will automatically
use this backend unless the backend configuration changes.
Upgrading modules...
- tenant in ../../modules/tenant
Downloading registry.terraform.io/Azure/avm-res-search-searchservice/azurerm 0.2.0 for tenant.ai_search...
- tenant.ai_search in /home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-ai-hub-admin/modules/tenant.ai_search
Downloading registry.terraform.io/Azure/avm-res-cognitiveservices-account/azurerm 0.7.1 for tenant.document_intelligence...
- tenant.document_intelligence in /home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-ai-hub-admin/modules/tenant.document_intelligence
Downloading registry.terraform.io/Azure/avm-res-keyvault-vault/azurerm 0.10.2 for tenant.key_vault...
- tenant.key_vault in /home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-ai-hub-admin/modules/tenant.key_vault
- tenant.key_vault.keys in /home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-ai-hub-admin/modules/tenant.key_vault/modules/key
- tenant.key_vault.secrets in /home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-ai-hub-admin/modules/tenant.key_vault/modules/secret
Downloading registry.terraform.io/Azure/avm-res-cognitiveservices-account/azurerm 0.7.1 for tenant.speech_services...
- tenant.speech_services in /home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-ai-hub-admin/modules/tenant.speech_services
Initializing provider plugins...
- terraform.io/builtin/terraform is built in to Terraform
- Finding hashicorp/azurerm versions matching ">= 3.117.0, ~> 4.0, >= 4.17.0, >= 4.38.0, < 5.0.0"...
- Finding hashicorp/null versions matching ">= 3.2.0"...
- Finding azure/modtm versions matching "~> 0.3"...
- Finding hashicorp/random versions matching ">= 3.5.0, ~> 3.5, >= 3.7.0, < 4.0.0"...
- Finding hashicorp/time versions matching "~> 0.9"...
- Finding azure/azapi versions matching "~> 2.0, ~> 2.4, >= 2.5.0"...
- Installing hashicorp/azurerm v4.81.0...
- Installed hashicorp/azurerm v4.81.0 (signed by HashiCorp)
- Installing hashicorp/null v3.3.0...
- Installed hashicorp/null v3.3.0 (signed by HashiCorp)
- Installing azure/modtm v0.4.0...
- Installed azure/modtm v0.4.0 (signed by a HashiCorp partner, key ID 6F0B91BDE98478CF)
- Installing hashicorp/random v3.9.0...
- Installed hashicorp/random v3.9.0 (signed by HashiCorp)
- Installing hashicorp/time v0.14.0...
- Installed hashicorp/time v0.14.0 (signed by HashiCorp)
- Installing azure/azapi v2.12.0...
- Installed azure/azapi v2.12.0 (signed by a HashiCorp partner, key ID 6F0B91BDE98478CF)
Partner and community providers are signed by their developers.
If you'd like to know more about provider signing, you can read about it here:
https://developer.hashicorp.com/terraform/cli/plugins/signing
Terraform has created a lock file .terraform.lock.hcl to record the provider
selections it made above. Include this file in your version control repository
so that Terraform can guarantee to make the same selections by default when
you run "terraform init" in the future.

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
2026-08-10T17:31:18Z [SUCCESS] terraform init (tenant:ai-hub-admin) completed successfully
2026-08-10T17:31:18Z [INFO] Starting terraform plan (tenant:ai-hub-admin) (attempt 1/5)
Acquiring state lock. This may take a few moments...
2026-08-10T17:31:23.629Z [ERROR] AttachSchemaTransformer: No provider config schema available for provider["terraform.io/builtin/terraform"]
2026-08-10T17:31:26.087Z [ERROR] AttachSchemaTransformer: No provider config schema available for provider["terraform.io/builtin/terraform"]
data.terraform_remote_state.shared: Reading...
module.tenant["ai-hub-admin"].random_string.suffix: Refreshing state... [id=418z]
data.terraform_remote_state.shared: Read complete after 1s
module.tenant["ai-hub-admin"].data.azurerm_client_config.current: Reading...
module.tenant["ai-hub-admin"].azurerm_resource_group.tenant: Refreshing state... [id=/subscriptions/****/resourceGroups/ai-hub-admin-rg]
module.tenant["ai-hub-admin"].data.azurerm_client_config.current: Read complete after 0s [id=Y2xpZW50Q29uZmlncy9jbGllbnRJZD1kZmZiM2UzZC1kMjU5LTQ2NmUtODUwYS1kOTEyYTI1NGViNjM7b2JqZWN0SWQ9YjE0NTQ5NTItNTg4ZS00MzUzLTk3ZTAtMTVhY2MwZGViYjcyO3N1YnNjcmlwdGlvbklkPTM0YzVlNmQ4LTA2NjUtNDg3Ny04MGE1LThjMGY1N2IxNGIzMzt0ZW5hbnRJZD02ZmRiNTIwMC0zZDBkLTRhOGEtYjAzNi1kMzY4NWUzNTlhZGM=]
module.tenant["ai-hub-admin"].module.document_intelligence[0].random_string.default_custom_subdomain_name_suffix[0]: Refreshing state... [id=kczgc]
module.tenant["ai-hub-admin"].azurerm_log_analytics_workspace.tenant[0]: Refreshing state... [id=/subscriptions/****/resourceGroups/ai-hub-admin-rg/providers/Microsoft.OperationalInsights/workspaces/aihubadmin-law-418z]
module.tenant["ai-hub-admin"].azurerm_storage_account.this[0]: Refreshing state... [id=/subscriptions/****/resourceGroups/ai-hub-admin-rg/providers/Microsoft.Storage/storageAccounts/aihubadminst418z]
module.tenant["ai-hub-admin"].module.document_intelligence[0].azurerm_cognitive_account.this[0]: Refreshing state... [id=/subscriptions/****/resourceGroups/ai-hub-admin-rg/providers/Microsoft.CognitiveServices/accounts/ai-hub-admin-docint-418z]
module.tenant["ai-hub-admin"].module.document_intelligence[0].azurerm_private_endpoint.this_unmanaged_dns_zone_groups["primary"]: Refreshing state... [id=/subscriptions/****/resourceGroups/ai-hub-admin-rg/providers/Microsoft.Network/privateEndpoints/pep-ai-hub-admin-docint-418z]
module.tenant["ai-hub-admin"].azurerm_application_insights.tenant[0]: Refreshing state... [id=/subscriptions/****/resourceGroups/ai-hub-admin-rg/providers/Microsoft.Insights/components/aihubadmin-appi-418z]
module.tenant["ai-hub-admin"].azurerm_monitor_diagnostic_setting.document_intelligence[0]: Refreshing state... [id=/subscriptions/****/resourceGroups/ai-hub-admin-rg/providers/Microsoft.CognitiveServices/accounts/ai-hub-admin-docint-418z|ai-hub-admin-docint-diag]
module.tenant["ai-hub-admin"].null_resource.wait_for_dns_document_intelligence[0]: Refreshing state... [id=2996673960704066107]
module.tenant["ai-hub-admin"].azurerm_storage_container.default[0]: Refreshing state... [id=/subscriptions/****/resourceGroups/ai-hub-admin-rg/providers/Microsoft.Storage/storageAccounts/aihubadminst418z/blobServices/default/containers/default]
module.tenant["ai-hub-admin"].azurerm_monitor_diagnostic_setting.storage[0]: Refreshing state... [id=/subscriptions/****/resourceGroups/ai-hub-admin-rg/providers/Microsoft.Storage/storageAccounts/aihubadminst418z|ai-hub-admin-storage-diag]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration
and found no differences, so no changes are needed.

Warning: Value for undeclared variable

The root module does not declare a variable named "defender_resource_types"
but a value was found in file
"/home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/params/test/shared.tfvars".
If you meant to use this value, add a "variable" block to the configuration.

To silence these warnings, use TF_VAR_... environment variables to provide
certain "global" settings to all configurations in your organization. To
reduce the verbosity of these warnings, use the -compact-warnings option.

Warning: Value for undeclared variable

The root module does not declare a variable named "defender_enabled" but a
value was found in file
"/home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/params/test/shared.tfvars".
If you meant to use this value, add a "variable" block to the configuration.

To silence these warnings, use TF_VAR_... environment variables to provide
certain "global" settings to all configurations in your organization. To
reduce the verbosity of these warnings, use the -compact-warnings option.

Warning: Argument is deprecated

  with module.tenant.azurerm_cosmosdb_account.this,
  on ../../modules/tenant/main.tf line 338, in resource "azurerm_cosmosdb_account" "this":
 338:   local_authentication_disabled     = true

`local_authentication_disabled` has been deprecated in favour of
`local_authentication_enabled` and will be removed in v5.0 of the AzureRM
Provider

Warning: Deprecated Resource

  with module.tenant.module.document_intelligence.azurerm_ai_services.this,
  on /home/runner/work/ai-hub-tracking/ai-hub-tracking/infra-ai-hub/.terraform-tenant-test-ai-hub-admin/modules/tenant.document_intelligence/main.aiservies.tf line 1, in resource "azurerm_ai_services" "this":
   1: resource "azurerm_ai_services" "this" {

The "azurerm_ai_services" resource has been deprecated and replaced by the
"azurerm_cognitive_account" resource.

The existing "azurerm_ai_services" resource will remain available until the
next
major version of the Azure Provider however the existing resource is
feature-frozen
and we recommend using the "azurerm_cognitive_account" resource instead.


(and one more similar warning elsewhere)
Releasing state lock. This may take a few moments...
2026-08-10T17:31:39Z [SUCCESS] terraform plan (tenant:ai-hub-admin) (attempt 1/5) completed successfully
2026-08-10T17:31:39Z [SUCCESS] tenant:ai-hub-admin completed successfully
2026-08-10T17:31:03Z [INFO] Starting terraform init (tenant:bc-archeology-portal)
Initializing the backend...

Successfully configured the backend "azurerm"! Terraform will automatically
use this backend unless the backend configuration changes.
Upgrading modules...
- tenant in ../../modules/tenant
Downloading registry.terraform.io/Azure/avm-res-search-searchservice/azurerm 0.2.0 for tenant.ai_search...
- tenant.ai_search in /home/runner/work/ai-hub-tracking/ai-hub-trackin
(truncated, see workflow logs for complete plan)
```

</details>

---
_Updated by CI — plan against `test` environment (run [#450](https://github.com/bcgov/ai-hub-tracking/actions/runs/31414047967)) at 2026-08-10 17:33:40 UTC._
<!-- /ai-hub-infra-changes -->